### PR TITLE
Deleteなど、bodyがnilの場合に制御を追加

### DIFF
--- a/client.go
+++ b/client.go
@@ -82,7 +82,7 @@ func (c *Client) call(ctx context.Context,
 	u.Path = path.Join(u.Path, APIPath1, apiPath)
 	u.RawQuery = queryParams.Encode()
 	var req *http.Request
-	if postBody == nil {
+	if method == http.MethodDelete {
 		// headers
 		req, err = http.NewRequest(method, u.String(), nil)
 		if err != nil {


### PR DESCRIPTION
[問題]

-  Deleteメソッドなど、bodyがnilのリクエストについては別分岐にしないとリクエスト形式不正でエラーになってしまう

```
{"lvl":"error","error":"{\"status_code\":400,\"errors\":[{\"type\":\"validation\",\"messages\":[\"リクエストの形式が不正です。\"]}]}","id":"61fcf2c4-d835-4215-b689-57910"2020-10-29T13:54:33+09:00","caller":"service/freee.go:798"}
```

[機能]

- callにおいて `bytes.NewBuffer(nil)` ではなく `nil` を設定し、`content-type:application/json`  を外した。
bodyが `nil` でheaderに `content-type:application/json` をつける場合がないという想定。
