### PR TITLE
fix(client): pointer arguments do not need to be returned

### DIFF
--- a/account_items.go
+++ b/account_items.go
@@ -67,8 +67,7 @@ func (c *Client) GetAccountItems(
 		return nil, oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, APIPathAccountItems, http.MethodGet, oauth2Token, v, nil, &result)
-	if err != nil {
+	if err = c.call(ctx, APIPathAccountItems, http.MethodGet, oauth2Token, v, nil, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 

--- a/companies.go
+++ b/companies.go
@@ -119,8 +119,7 @@ func (c *Client) GetCompany(
 	if err != nil {
 		return nil, oauth2Token, err
 	}
-	oauth2Token, err = c.call(ctx, path.Join(APIPathCompanies, fmt.Sprint(companyID)), http.MethodGet, oauth2Token, v, nil, &result)
-	if err != nil {
+	if err = c.call(ctx, path.Join(APIPathCompanies, fmt.Sprint(companyID)), http.MethodGet, oauth2Token, v, nil, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result, oauth2Token, nil

--- a/deals.go
+++ b/deals.go
@@ -256,7 +256,7 @@ func (c *Client) GetDeal(
 		return nil, oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, path.Join(APIPathDeals, fmt.Sprint(dealID)), http.MethodGet, oauth2Token, v, nil, &result)
+	err = c.call(ctx, path.Join(APIPathDeals, fmt.Sprint(dealID)), http.MethodGet, oauth2Token, v, nil, &result)
 	if err != nil {
 		return nil, oauth2Token, err
 	}
@@ -268,8 +268,7 @@ func (c *Client) CreateDeal(
 	params DealCreateParams,
 ) (*Deal, *oauth2.Token, error) {
 	var result DealResponse
-	oauth2Token, err := c.call(ctx, APIPathDeals, http.MethodPost, oauth2Token, nil, params, &result)
-	if err != nil {
+	if err := c.call(ctx, APIPathDeals, http.MethodPost, oauth2Token, nil, params, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result.Deal, oauth2Token, nil
@@ -280,8 +279,7 @@ func (c *Client) UpdateDeal(
 	dealID uint64, params DealUpdateParams,
 ) (*Deal, *oauth2.Token, error) {
 	var result DealResponse
-	oauth2Token, err := c.call(ctx, path.Join(APIPathDeals, fmt.Sprint(dealID)), http.MethodPut, oauth2Token, nil, params, &result)
-	if err != nil {
+	if err := c.call(ctx, path.Join(APIPathDeals, fmt.Sprint(dealID)), http.MethodPut, oauth2Token, nil, params, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result.Deal, oauth2Token, nil
@@ -296,8 +294,7 @@ func (c *Client) DestroyDeal(
 		return oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, path.Join(APIPathDeals, fmt.Sprint(dealID)), http.MethodDelete, oauth2Token, v, nil, nil)
-	if err != nil {
+	if err = c.call(ctx, path.Join(APIPathDeals, fmt.Sprint(dealID)), http.MethodDelete, oauth2Token, v, nil, nil); err != nil {
 		return oauth2Token, err
 	}
 

--- a/items.go
+++ b/items.go
@@ -62,8 +62,7 @@ func (c *Client) GetItems(
 		return nil, oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, APIPathItems, http.MethodGet, oauth2Token, v, nil, &result)
-	if err != nil {
+	if err = c.call(ctx, APIPathItems, http.MethodGet, oauth2Token, v, nil, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 
@@ -75,8 +74,7 @@ func (c *Client) CreateItem(
 	params ItemParams,
 ) (*Item, *oauth2.Token, error) {
 	var result ItemResponse
-	oauth2Token, err := c.call(ctx, APIPathItems, http.MethodPost, oauth2Token, nil, params, &result)
-	if err != nil {
+	if err := c.call(ctx, APIPathItems, http.MethodPost, oauth2Token, nil, params, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result.Item, oauth2Token, nil
@@ -88,8 +86,7 @@ func (c *Client) UpdateItem(
 	itemID uint32,
 ) (*Item, *oauth2.Token, error) {
 	var result ItemResponse
-	oauth2Token, err := c.call(ctx, path.Join(APIPathItems, fmt.Sprint(itemID)), http.MethodPut, oauth2Token, nil, params, &result)
-	if err != nil {
+	if err := c.call(ctx, path.Join(APIPathItems, fmt.Sprint(itemID)), http.MethodPut, oauth2Token, nil, params, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result.Item, oauth2Token, nil
@@ -104,8 +101,7 @@ func (c *Client) DestroyItem(
 		return oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, path.Join(APIPathItems, fmt.Sprint(itemID)), http.MethodDelete, oauth2Token, v, nil, nil)
-	if err != nil {
+	if err = c.call(ctx, path.Join(APIPathItems, fmt.Sprint(itemID)), http.MethodDelete, oauth2Token, v, nil, nil); err != nil {
 		return oauth2Token, err
 	}
 

--- a/manual_journals.go
+++ b/manual_journals.go
@@ -173,8 +173,7 @@ func (c *Client) CreateManualJournal(
 ) (*ManualJournalResponse, *oauth2.Token, error) {
 	var result ManualJournalResponse
 
-	oauth2Token, err := c.call(ctx, APIPathManualJournals, http.MethodPost, oauth2Token, nil, params, &result)
-	if err != nil {
+	if err := c.call(ctx, APIPathManualJournals, http.MethodPost, oauth2Token, nil, params, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 
@@ -187,8 +186,7 @@ func (c *Client) UpdateManualJournal(
 ) (*ManualJournalResponse, *oauth2.Token, error) {
 	var result ManualJournalResponse
 
-	oauth2Token, err := c.call(ctx, path.Join(APIPathManualJournals, fmt.Sprint(journalID)), http.MethodPut, oauth2Token, nil, params, &result)
-	if err != nil {
+	if err := c.call(ctx, path.Join(APIPathManualJournals, fmt.Sprint(journalID)), http.MethodPut, oauth2Token, nil, params, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 
@@ -204,8 +202,7 @@ func (c *Client) DestroyManualJournal(
 		return oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, path.Join(APIPathManualJournals, fmt.Sprint(journalID)), http.MethodDelete, oauth2Token, v, nil, nil)
-	if err != nil {
+	if err = c.call(ctx, path.Join(APIPathManualJournals, fmt.Sprint(journalID)), http.MethodDelete, oauth2Token, v, nil, nil); err != nil {
 		return oauth2Token, err
 	}
 

--- a/partners.go
+++ b/partners.go
@@ -207,8 +207,7 @@ func (c *Client) CreatePartner(
 ) (*Partner, *oauth2.Token, error) {
 	var result PartnerResponse
 
-	oauth2Token, err := c.call(ctx, APIPathPartners, http.MethodPost, oauth2Token, nil, params, &result)
-	if err != nil {
+	if err := c.call(ctx, APIPathPartners, http.MethodPost, oauth2Token, nil, params, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 
@@ -260,8 +259,7 @@ func (c *Client) UpdatePartner(
 ) (*Partner, *oauth2.Token, error) {
 	var result PartnerResponse
 
-	oauth2Token, err := c.call(ctx, path.Join(APIPathPartners, fmt.Sprint(partnerID)), http.MethodPut, oauth2Token, nil, params, &result)
-	if err != nil {
+	if err := c.call(ctx, path.Join(APIPathPartners, fmt.Sprint(partnerID)), http.MethodPut, oauth2Token, nil, params, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 
@@ -288,8 +286,7 @@ func (c *Client) GetPartners(
 		return nil, oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, APIPathPartners, http.MethodGet, oauth2Token, v, nil, &result)
-	if err != nil {
+	if err = c.call(ctx, APIPathPartners, http.MethodGet, oauth2Token, v, nil, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 
@@ -305,8 +302,7 @@ func (c *Client) DestroyPartner(
 		return oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, path.Join(APIPathPartners, fmt.Sprint(partnerID)), http.MethodDelete, oauth2Token, v, nil, nil)
-	if err != nil {
+	if err = c.call(ctx, path.Join(APIPathPartners, fmt.Sprint(partnerID)), http.MethodDelete, oauth2Token, v, nil, nil); err != nil {
 		return oauth2Token, err
 	}
 

--- a/receipts.go
+++ b/receipts.go
@@ -85,8 +85,7 @@ func (c *Client) CreateReceipt(
 		"issue_date":  params.IssueDate,
 	}
 	var result ReceiptResponse
-	oauth2Token, err := c.postFiles(ctx, APIPathReceipts, http.MethodPost, oauth2Token, nil, postBody, receiptName, params.Receipt, &result)
-	if err != nil {
+	if err := c.postFiles(ctx, APIPathReceipts, http.MethodPost, oauth2Token, nil, postBody, receiptName, params.Receipt, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result, oauth2Token, nil
@@ -102,8 +101,7 @@ func (c *Client) GetReceipt(
 		return nil, oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, path.Join(APIPathReceipts, fmt.Sprint(receiptID)), http.MethodGet, oauth2Token, v, nil, &result)
-	if err != nil {
+	if err = c.call(ctx, path.Join(APIPathReceipts, fmt.Sprint(receiptID)), http.MethodGet, oauth2Token, v, nil, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result, oauth2Token, nil

--- a/sections.go
+++ b/sections.go
@@ -61,8 +61,7 @@ func (c *Client) GetSections(
 		return nil, oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, APIPathSections, http.MethodGet, oauth2Token, v, nil, &result)
-	if err != nil {
+	if err = c.call(ctx, APIPathSections, http.MethodGet, oauth2Token, v, nil, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 
@@ -74,8 +73,7 @@ func (c *Client) CreateSection(
 	params SectionParams,
 ) (*Section, *oauth2.Token, error) {
 	var result SectionResponse
-	oauth2Token, err := c.call(ctx, APIPathSections, http.MethodPost, oauth2Token, nil, params, &result)
-	if err != nil {
+	if err := c.call(ctx, APIPathSections, http.MethodPost, oauth2Token, nil, params, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result.Section, oauth2Token, nil
@@ -86,8 +84,7 @@ func (c *Client) UpdateSection(
 	sectionID uint32, params SectionParams,
 ) (*Section, *oauth2.Token, error) {
 	var result SectionResponse
-	oauth2Token, err := c.call(ctx, path.Join(APIPathSections, fmt.Sprint(sectionID)), http.MethodPut, oauth2Token, nil, params, &result)
-	if err != nil {
+	if err := c.call(ctx, path.Join(APIPathSections, fmt.Sprint(sectionID)), http.MethodPut, oauth2Token, nil, params, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result.Section, oauth2Token, nil
@@ -102,8 +99,7 @@ func (c *Client) DestroySection(
 		return oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, path.Join(APIPathSections, fmt.Sprint(sectionID)), http.MethodDelete, oauth2Token, v, nil, nil)
-	if err != nil {
+	if err = c.call(ctx, path.Join(APIPathSections, fmt.Sprint(sectionID)), http.MethodDelete, oauth2Token, v, nil, nil); err != nil {
 		return oauth2Token, err
 	}
 

--- a/segment_tags.go
+++ b/segment_tags.go
@@ -68,8 +68,7 @@ func (c *Client) GetSegmentTags(
 		return nil, oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, path.Join(APIPathSegments, fmt.Sprint(segmentID), "tags"), http.MethodGet, oauth2Token, v, nil, &result)
-	if err != nil {
+	if err = c.call(ctx, path.Join(APIPathSegments, fmt.Sprint(segmentID), "tags"), http.MethodGet, oauth2Token, v, nil, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 
@@ -81,8 +80,7 @@ func (c *Client) CreateSegmentTag(
 	segmentID uint32, params SegmentTagParams,
 ) (*SegmentTag, *oauth2.Token, error) {
 	var result SegmentTagResponse
-	oauth2Token, err := c.call(ctx, path.Join(APIPathSegments, fmt.Sprint(segmentID), "tags"), http.MethodPost, oauth2Token, nil, params, &result)
-	if err != nil {
+	if err := c.call(ctx, path.Join(APIPathSegments, fmt.Sprint(segmentID), "tags"), http.MethodPost, oauth2Token, nil, params, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result.SegmentTag, oauth2Token, nil
@@ -94,8 +92,7 @@ func (c *Client) UpdateSegmentTag(
 	params SegmentTagParams,
 ) (*SegmentTag, *oauth2.Token, error) {
 	var result SegmentTagResponse
-	oauth2Token, err := c.call(ctx, path.Join(APIPathSegments, fmt.Sprint(segmentID), "tags", fmt.Sprint(id)), http.MethodPut, oauth2Token, nil, params, &result)
-	if err != nil {
+	if err := c.call(ctx, path.Join(APIPathSegments, fmt.Sprint(segmentID), "tags", fmt.Sprint(id)), http.MethodPut, oauth2Token, nil, params, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result.SegmentTag, oauth2Token, nil
@@ -111,8 +108,7 @@ func (c *Client) DestroySegmentTag(
 		return oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, path.Join(APIPathSegments, fmt.Sprint(segmentID), "tags", fmt.Sprint(id)), http.MethodDelete, oauth2Token, v, nil, nil)
-	if err != nil {
+	if err = c.call(ctx, path.Join(APIPathSegments, fmt.Sprint(segmentID), "tags", fmt.Sprint(id)), http.MethodDelete, oauth2Token, v, nil, nil); err != nil {
 		return oauth2Token, err
 	}
 

--- a/tags.go
+++ b/tags.go
@@ -62,8 +62,7 @@ func (c *Client) GetTags(
 		return nil, oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, APIPathTags, http.MethodGet, oauth2Token, v, nil, &result)
-	if err != nil {
+	if err = c.call(ctx, APIPathTags, http.MethodGet, oauth2Token, v, nil, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 
@@ -75,8 +74,7 @@ func (c *Client) CreateTag(
 	params TagParams,
 ) (*Tag, *oauth2.Token, error) {
 	var result TagResponse
-	oauth2Token, err := c.call(ctx, APIPathTags, http.MethodPost, oauth2Token, nil, params, &result)
-	if err != nil {
+	if err := c.call(ctx, APIPathTags, http.MethodPost, oauth2Token, nil, params, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result.Tag, oauth2Token, nil
@@ -87,8 +85,7 @@ func (c *Client) UpdateTag(
 	tagID uint32, params TagParams,
 ) (*Tag, *oauth2.Token, error) {
 	var result TagResponse
-	oauth2Token, err := c.call(ctx, path.Join(APIPathTags, fmt.Sprint(tagID)), http.MethodPut, oauth2Token, nil, params, &result)
-	if err != nil {
+	if err := c.call(ctx, path.Join(APIPathTags, fmt.Sprint(tagID)), http.MethodPut, oauth2Token, nil, params, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result.Tag, oauth2Token, nil
@@ -103,8 +100,7 @@ func (c *Client) DestroyTag(
 		return oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, path.Join(APIPathTags, fmt.Sprint(tagID)), http.MethodDelete, oauth2Token, v, nil, nil)
-	if err != nil {
+	if err = c.call(ctx, path.Join(APIPathTags, fmt.Sprint(tagID)), http.MethodDelete, oauth2Token, v, nil, nil); err != nil {
 		return oauth2Token, err
 	}
 

--- a/taxes.go
+++ b/taxes.go
@@ -52,8 +52,7 @@ func (c *Client) GetTaxCompanies(
 		return nil, oauth2Token, err
 	}
 	SetCompanyID(&v, companyID)
-	oauth2Token, err = c.call(ctx, path.Join(APIPathTaxes, "companies", fmt.Sprint(companyID)), http.MethodGet, oauth2Token, v, nil, &result)
-	if err != nil {
+	if err = c.call(ctx, path.Join(APIPathTaxes, "companies", fmt.Sprint(companyID)), http.MethodGet, oauth2Token, v, nil, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result, oauth2Token, nil

--- a/users.go
+++ b/users.go
@@ -60,8 +60,7 @@ func (c *Client) GetUsersMe(
 	if err != nil {
 		return nil, oauth2Token, err
 	}
-	oauth2Token, err = c.call(ctx, path.Join(APIPathUsers, "me"), http.MethodGet, oauth2Token, v, nil, &result)
-	if err != nil {
+	if err = c.call(ctx, path.Join(APIPathUsers, "me"), http.MethodGet, oauth2Token, v, nil, &result); err != nil {
 		return nil, oauth2Token, err
 	}
 	return &result, oauth2Token, nil


### PR DESCRIPTION
ポインタを引数で渡した場合、実際の値を渡しているわけではないので、戻り値として返却する必要はありません。
（返却時に引数の`oauth2Token`と戻り値の`oauth2Token`は同じになります）
bug riskになるのでむしろ返却しないほうがいいです。

すでに利用している方に影響が出ないように、プライベートメソッドだけ対応しました。