### PR TITLE
int32で桁溢れが発生しているためint系のデータ型をint64に統一

### DIFF
--- a/account_items.go
+++ b/account_items.go
@@ -22,7 +22,7 @@ type AccountItems struct {
 
 type AccountItem struct {
 	// 勘定科目ID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// 勘定科目コード
 	Code *string `json:"code,omitempty"`
 	// 勘定科目名 (30文字以内)
@@ -32,49 +32,49 @@ type AccountItem struct {
 	// ショートカット2(勘定科目コード) (20文字以内)
 	ShortcutNum *string `json:"shortcut_num,omitempty"`
 	// 税区分コード
-	TaxCode int32 `json:"tax_code"`
+	TaxCode int64 `json:"tax_code"`
 	// デフォルト設定がされている税区分ID
-	DefaultTaxID int32 `json:"default_tax_id,omitempty"`
+	DefaultTaxID int64 `json:"default_tax_id,omitempty"`
 	// デフォルト設定がされている税区分コード
-	DefaultTaxCode int32 `json:"default_tax_code"`
+	DefaultTaxCode int64 `json:"default_tax_code"`
 	// 勘定科目カテゴリー
 	AccountCategory string `json:"account_category"`
 	// 勘定科目のカテゴリーID
-	AccountCategoryID int32    `json:"account_category_id"`
+	AccountCategoryID int64    `json:"account_category_id"`
 	Categories        []string `json:"categories"`
 	// 勘定科目の使用設定（true: 使用する、false: 使用しない）
 	Available bool `json:"available"`
 	// 口座ID
-	WalletableID *int32 `json:"walletable_id"`
+	WalletableID *int64 `json:"walletable_id"`
 	// 決算書表示名（小カテゴリー）
 	GroupName *string `json:"group_name,omitempty"`
 	// 収入取引相手勘定科目名
 	CorrespondingIncomeName *string `json:"corresponding_income_name,omitempty"`
 	// 収入取引相手勘定科目ID
-	CorrespondingIncomeID *int32 `json:"corresponding_income_id,omitempty"`
+	CorrespondingIncomeID *int64 `json:"corresponding_income_id,omitempty"`
 	// 支出取引相手勘定科目名
 	CorrespondingExpenseName *string `json:"corresponding_expense_name,omitempty"`
 	// 支出取引相手勘定科目ID
-	CorrespondingExpenseID *int32 `json:"corresponding_expense_id,omitempty"`
+	CorrespondingExpenseID *int64 `json:"corresponding_expense_id,omitempty"`
 }
 
 type AccountItemCreateParams struct {
 	// 事業所ID
-	CompanyID   int32                              `json:"company_id"`
+	CompanyID   int64                              `json:"company_id"`
 	AccountItem AccountItemCreateParamsAccountItem `json:"account_item"`
 }
 
 type AccountItemCreateParamsAccountItem struct {
 	// 勘定科目カテゴリーID Selectablesフォーム用選択項目情報エンドポイント(account_groups.account_category_id)で取得可能です
-	AccountCategoryID int32 `json:"account_category_id"`
+	AccountCategoryID int64 `json:"account_category_id"`
 	// 減価償却累計額勘定科目ID（法人のみ利用可能）
-	AccumulatedDepAccountItemID *int32 `json:"accumulated_dep_account_item_id,omitempty"`
+	AccumulatedDepAccountItemID *int64 `json:"accumulated_dep_account_item_id,omitempty"`
 	// 勘定科目コード
 	Code *string `json:"code,omitempty"`
 	// 支出取引相手勘定科目ID
-	CorrespondingExpenseID int32 `json:"corresponding_expense_id"`
+	CorrespondingExpenseID int64 `json:"corresponding_expense_id"`
 	// 収入取引相手勘定科目ID
-	CorrespondingIncomeID int32 `json:"corresponding_income_id"`
+	CorrespondingIncomeID int64 `json:"corresponding_income_id"`
 	// 決算書表示名（小カテゴリー） Selectablesフォーム用選択項目情報エンドポイント(account_groups.name)で取得可能です
 	GroupName string `json:"group_name"`
 	// 品目
@@ -84,21 +84,21 @@ type AccountItemCreateParamsAccountItem struct {
 	// 取引先
 	Partners *[]AccountItemCreateParamsPartners `json:"partners,omitempty"`
 	// 検索可能:2, 検索不可：3(登録時未指定の場合は2で登録されます。更新時未指定の場合はsearchableは変更されません。)
-	Searchable *int32 `json:"searchable,omitempty"`
+	Searchable *int64 `json:"searchable,omitempty"`
 	// ショートカット1 (20文字以内)
 	Shortcut *string `json:"shortcut,omitempty"`
 	// ショートカット2 (20文字以内)
 	ShortcutNum *string `json:"shortcut_num,omitempty"`
 	// 税区分コード 指定できるコードは本APIの注意点をご確認ください。
-	TaxCode int32 `json:"tax_code"`
+	TaxCode int64 `json:"tax_code"`
 }
 
 type AccountItemCreateParamsItems struct {
-	ID *int32 `json:"id,omitempty"`
+	ID *int64 `json:"id,omitempty"`
 }
 
 type AccountItemCreateParamsPartners struct {
-	ID *int32 `json:"id,omitempty"`
+	ID *int64 `json:"id,omitempty"`
 }
 
 type AccountItemCreateResponse struct {
@@ -108,17 +108,17 @@ type AccountItemCreateResponse struct {
 // AccountItemDetail はPOST /api/1/account_items のレスポンス。
 type AccountItemDetail struct {
 	// 勘定科目ID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// 勘定科目名 (30文字以内)
 	Name string `json:"name"`
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 税区分コード
-	TaxCode int32 `json:"tax_code"`
+	TaxCode int64 `json:"tax_code"`
 	// 勘定科目カテゴリー
 	AccountCategory string `json:"account_category"`
 	// 勘定科目のカテゴリーID
-	AccountCategoryID int32 `json:"account_category_id"`
+	AccountCategoryID int64 `json:"account_category_id"`
 	// ショートカット1 (20文字以内)
 	Shortcut *string `json:"shortcut,omitempty"`
 	// ショートカット2 (20文字以内)
@@ -126,11 +126,11 @@ type AccountItemDetail struct {
 	// 勘定科目コード (20文字以内)
 	Code *string `json:"code"`
 	// 検索可能:2, 検索不可：3
-	Searchable int32 `json:"searchable"`
+	Searchable int64 `json:"searchable"`
 	// 減価償却累計額勘定科目（法人のみ利用可能）
 	AccumulatedDepAccountItemName *string `json:"accumulated_dep_account_item_name,omitempty"`
 	// 減価償却累計額勘定科目ID（法人のみ利用可能）
-	AccumulatedDepAccountItemID *int32 `json:"accumulated_dep_account_item_id"`
+	AccumulatedDepAccountItemID *int64 `json:"accumulated_dep_account_item_id"`
 	// 品目
 	Items *[]AccountItemDetalItems `json:"items,omitempty"`
 	// 取引先
@@ -138,38 +138,38 @@ type AccountItemDetail struct {
 	// 勘定科目の使用設定（true: 使用する、false: 使用しない）
 	Available bool `json:"available"`
 	// 口座ID
-	WalletableID *int32 `json:"walletable_id"`
+	WalletableID *int64 `json:"walletable_id"`
 	// 決算書表示名（小カテゴリー）
 	GroupName *string `json:"group_name,omitempty"`
 	// 決算書表示名ID（小カテゴリー）
-	GroupID *int32 `json:"group_id"`
+	GroupID *int64 `json:"group_id"`
 	// 収入取引相手勘定科目名
 	CorrespondingIncomeName *string `json:"corresponding_income_name,omitempty"`
 	// 収入取引相手勘定科目ID
-	CorrespondingIncomeID *int32 `json:"corresponding_income_id,omitempty"`
+	CorrespondingIncomeID *int64 `json:"corresponding_income_id,omitempty"`
 	// 支出取引相手勘定科目名
 	CorrespondingExpenseName *string `json:"corresponding_expense_name,omitempty"`
 	// 支出取引相手勘定科目ID
-	CorrespondingExpenseID *int32 `json:"corresponding_expense_id,omitempty"`
+	CorrespondingExpenseID *int64 `json:"corresponding_expense_id,omitempty"`
 }
 
 type AccountItemDetalItems struct {
 	// 品目ID
-	ID *int32 `json:"id,omitempty"`
+	ID *int64 `json:"id,omitempty"`
 	// 品目名
 	Name string `json:"name"`
 }
 
 type AccountItemDetailPartners struct {
 	// 取引先ID
-	ID *int32 `json:"id,omitempty"`
+	ID *int64 `json:"id,omitempty"`
 	// 取引先名
 	Name string `json:"name"`
 }
 
 func (c *Client) GetAccountItems(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, opts GetAccountItemsOpts,
+	companyID int64, opts GetAccountItemsOpts,
 ) (*AccountItems, *oauth2.Token, error) {
 	var result AccountItems
 

--- a/companies.go
+++ b/companies.go
@@ -20,7 +20,7 @@ type CompanyResponse struct {
 
 type Company struct {
 	// 事業所ID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// 事業所の正式名称 (100文字以内)
 	Name *string `json:"name"`
 	// 正式名称フリガナ (100文字以内)
@@ -28,21 +28,21 @@ type Company struct {
 	// 事業所名
 	DisplayName string `json:"display_name"`
 	// 源泉徴収税計算（0: 消費税を含める、1: 消費税を含めない）
-	TaxAtSourceCalcType int32 `json:"tax_at_source_calc_type"`
+	TaxAtSourceCalcType int64 `json:"tax_at_source_calc_type"`
 	// 担当者名 (50文字以内)
 	ContactName *string `json:"contact_name"`
 	// 従業員数（0: 経営者のみ、1: 2~5人、2: 6~10人、3: 11~20人、4: 21~30人、5: 31~40人、6: 41~100人、7: 100人以上
-	HeadCount *int32 `json:"head_count"`
+	HeadCount *int64 `json:"head_count"`
 	// 法人番号 (半角数字13桁、法人のみ)
 	CorporateNumber string `json:"corporate_number"`
 	// 仕訳番号形式（not_used: 使用しない、digits: 数字（例：5091824）、alnum: 英数字（例：59J0P））
 	TxnNumberFormat string `json:"txn_number_format"`
 	// 決済口座のデフォルト
-	DefaultWalletAccountId *int32 `json:"default_wallet_account_id,omitempty"`
+	DefaultWalletAccountId *int64 `json:"default_wallet_account_id,omitempty"`
 	// プライベート資金/役員資金（false: 使用しない、true: 使用する）
 	PrivateSettlement bool `json:"private_settlement"`
 	// マイナスの表示方法（0: -、 1: △）
-	MinusFormat int32 `json:"minus_format"`
+	MinusFormat int64 `json:"minus_format"`
 	// ユーザーの権限
 	Role string `json:"role"`
 	// 電話番号１
@@ -54,7 +54,7 @@ type Company struct {
 	// 郵便番号
 	Zipcode string `json:"zipcode"`
 	// 都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄
-	PrefectureCode *int32 `json:"prefecture_code"`
+	PrefectureCode *int64 `json:"prefecture_code"`
 	// 市区町村・番地
 	StreetName1 string `json:"street_name1"`
 	// 建物名・部屋番号など
@@ -62,7 +62,7 @@ type Company struct {
 	// 請求書レイアウト * `default_classic` - レイアウト１/クラシック (デフォルト)  * `standard_classic` - レイアウト２/クラシック  * `envelope_classic` - 封筒１/クラシック  * `carried_forward_standard_classic` - レイアウト３（繰越金額欄あり）/クラシック  * `carried_forward_envelope_classic` - 封筒２（繰越金額欄あり）/クラシック  * `default_modern` - レイアウト１/モダン  * `standard_modern` - レイアウト２/モダン  * `envelope_modern` - 封筒/モダン
 	InvoiceLayout string `json:"invoice_layout"`
 	// 金額端数処理方法（0: 切り捨て、1: 切り上げ、2: 四捨五入）
-	AmountFraction int32 `json:"amount_fraction"`
+	AmountFraction int64 `json:"amount_fraction"`
 	// 種別（agriculture_forestry_fisheries_ore: 農林水産業/鉱業、construction: 建設、manufacturing_processing: 製造/加工、it: IT、transportation_logistics: 運輸/物流、retail_wholesale: 小売/卸売、finance_insurance: 金融/保険、real_estate_rental: 不動産/レンタル、profession: 士業/学術/専門技術サービス、design_production: デザイン/制作、food: 飲食、leisure_entertainment: レジャー/娯楽、lifestyle: 生活関連サービス、education: 教育/学習支援、medical_welfare: 医療/福祉、other_services: その他サービス、other: その他）
 	IndustryClass string `json:"industry_class"`
 	// 業種（agriculture: 農業, forestry: 林業, fishing_industry: 漁業、水産養殖業, mining: 鉱業、採石業、砂利採取業, civil_contractors: 土木工事業, pavement: 舗装工事業, carpenter: とび、大工、左官等の建設工事業, renovation: リフォーム工事業, electrical_plumbing: 電気、管工事等の設備工事業, grocery: 食料品の製造加工業, machinery_manufacturing: 機械器具の製造加工業, printing: 印刷業, other_manufacturing: その他の製造加工業, software_development: 受託：ソフトウェア、アプリ開発業, system_development: 受託：システム開発業, survey_analysis: 受託：調査、分析等の情報処理業, server_management: 受託：サーバー運営管理, website_production: 受託：ウェブサイト制作, online_service_management: オンラインサービス運営業, online_advertising_agency: オンライン広告代理店業, online_advertising_planning_production: オンライン広告企画・制作業, online_media_management: オンラインメディア運営業, portal_site_management: ポータルサイト運営業, other_it_services: その他、IT サービス業, transport_delivery: 輸送業、配送業, delivery: バイク便等の配達業, other_transportation_logistics: その他の運輸業、物流業, other_wholesale: 卸売業：その他, clothing_wholesale_fiber: 卸売業：衣類卸売／繊維, food_wholesale: 卸売業：飲食料品, entrusted_development_wholesale: 卸売業：機械器具, online_shop: 小売業：無店舗　オンラインショップ, fashion_grocery_store: 小売業：店舗あり　ファッション、雑貨, food_store: 小売業：店舗あり　生鮮食品、飲食料品, entrusted_store: 小売業：店舗あり　機械、器具, other_store: 小売業：店舗あり　その他, financial_instruments_exchange: 金融業：金融商品取引, commodity_futures_investment_advisor: 金融業：商品先物取引、商品投資顧問, other_financial: 金融業：その他, brokerage_insurance: 保険業：仲介、代理, other_insurance: 保険業：その他, real_estate_developer: 不動産業：ディベロッパー, real_estate_brokerage: 不動産業：売買、仲介, rent_coin_parking_management: 不動産業：賃貸、コインパーキング、管理, rental_office_co_working_space: 不動産業：レンタルオフィス、コワーキングスペース, rental_lease: レンタル業、リース業, cpa_tax_accountant: 士業：公認会計士事務所、税理士事務所, law_office: 士業：法律事務所, judicial_and_administrative_scrivener: 士業：司法書士事務所／行政書士事務所, labor_consultant: 士業：社会保険労務士事務所, other_profession: 士業：その他, business_consultant: 経営コンサルタント, academic_research_development: 学術・開発研究機関, advertising_agency: 広告代理店, advertising_planning_production: 広告企画／制作, design_development: ソフトウェア、アプリ開発業（受託）, apparel_industry_design: 服飾デザイン業、工業デザイン業, website_design: ウェブサイト制作（受託）, advertising_planning_design: 広告企画／制作業, other_design: その他、デザイン／制作, restaurants_coffee_shops: レストラン、喫茶店等の飲食店業, sale_of_lunch: 弁当の販売業, bread_confectionery_manufacture_sale: パン、菓子等の製造販売業, delivery_catering_mobile_catering: デリバリー業、ケータリング業、移動販売業, hotel_inn: 宿泊業：ホテル、旅館, homestay: 宿泊業：民泊, travel_agency: 旅行代理店業, leisure_sports_facility_management: レジャー、スポーツ等の施設運営業, show_event_management: ショー、イベント等の興行、イベント運営業, barber: ビューティ、ヘルスケア業：床屋、理容室, beauty_salon: ビューティ、ヘルスケア業：美容室, spa_sand_bath_sauna: ビューティ、ヘルスケア業：スパ、砂風呂、サウナ等, este_ail_salon: ビューティ、ヘルスケア業：その他、エステサロン、ネイルサロン等, bridal_planning_introduce_wedding: 冠婚葬祭業：ブライダルプランニング、結婚式場紹介等, memorial_ceremony_funeral: 冠婚葬祭業：メモリアルセレモニー、葬儀等, moving: 引っ越し業, courier_industry: 宅配業, house_maid_cleaning_agency: 家事代行サービス業：無店舗　ハウスメイド、掃除代行等, re_tailoring_clothes: 家事代行サービス業：店舗あり　衣類修理、衣類仕立て直し等, training_institute_management: 研修所等の施設運営業, tutoring_school: 学習塾、進学塾等の教育・学習支援業, music_calligraphy_abacus_classroom: 音楽教室、書道教室、そろばん教室等のの教育・学習支援業, english_school: 英会話スクール等の語学学習支援業, tennis_yoga_judo_school: テニススクール、ヨガ教室、柔道場等のスポーツ指導、支援業, culture_school: その他、カルチャースクール等の教育・学習支援業, seminar_planning_management: セミナー等の企画、運営業, hospital_clinic: 医療業：病院、一般診療所、クリニック等, dental_clinic: 医療業：歯科診療所, other_medical_services: 医療業：その他、医療サービス等, nursery: 福祉業：保育所等、児童向け施設型サービス, nursing_home: 福祉業：老人ホーム等、老人向け施設型サービス, rehabilitation_support_services: 福祉業：療育支援サービス等、障害者等向け施設型サービス, other_welfare: 福祉業：その他、施設型福祉サービス, visit_welfare_service: 福祉業：訪問型福祉サービス, recruitment_temporary_staffing: 人材紹介業、人材派遣業, life_related_recruitment_temporary_staffing: 生活関連サービスの人材紹介業、人材派遣業, car_maintenance_car_repair: 自動車整備業、自動車修理業, machinery_equipment_maintenance_repair: 機械機器類の整備業、修理業, cleaning_maintenance_building_management: 清掃業、メンテナンス業、建物管理業, security: 警備業, other_services: その他のサービス業, npo: NPO, general_incorporated_association: 一般社団法人, general_incorporated_foundation: 一般財団法人, other_association: その他組織)
@@ -85,17 +85,17 @@ type FiscalYears struct {
 	// 期末日
 	EndDate *string `json:"end_date,omitempty"`
 	// 月次償却（0: しない、1: する）
-	DepreciationRecordMethod int32 `json:"depreciation_record_method"`
+	DepreciationRecordMethod int64 `json:"depreciation_record_method"`
 	// 課税区分（0: 免税、1: 簡易課税、2: 本則課税（個別対応方式）、3: 本則課税（一括比例配分方式）、4: 本則課税（全額控除））
-	TaxMethod int32 `json:"tax_method"`
+	TaxMethod int64 `json:"tax_method"`
 	// 簡易課税用事業区分（0: 第一種：卸売業、1: 第二種：小売業、2: 第三種：農林水産業、工業、建設業、製造業など、3: 第四種：飲食店業など、4: 第五種：金融・保険業、運輸通信業、サービス業など、5: 第六種：不動産業など
-	SalesTaxBusinessCode int32 `json:"sales_tax_business_code"`
+	SalesTaxBusinessCode int64 `json:"sales_tax_business_code"`
 	// 消費税端数処理方法（0: 切り捨て、1: 切り上げ、2: 四捨五入）
-	TaxFraction int32 `json:"tax_fraction"`
+	TaxFraction int64 `json:"tax_fraction"`
 	// 消費税経理処理方法（0: 税込経理、1: 旧税抜経理、2: 税抜経理）
-	TaxAccountMethod int32 `json:"tax_account_method"`
+	TaxAccountMethod int64 `json:"tax_account_method"`
 	// 不動産所得使用区分（0: 一般、3: 一般/不動産） ※個人事業主のみ設定可能
-	ReturnCode int32 `json:"return_code"`
+	ReturnCode int64 `json:"return_code"`
 }
 
 type GetCompanyOpts struct {
@@ -111,7 +111,7 @@ type GetCompanyOpts struct {
 
 func (c *Client) GetCompany(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, opts GetCompanyOpts,
+	companyID int64, opts GetCompanyOpts,
 ) (*CompanyResponse, *oauth2.Token, error) {
 	var result CompanyResponse
 

--- a/deals.go
+++ b/deals.go
@@ -27,7 +27,7 @@ type DealsResponse struct {
 }
 
 type DealsResponseMeta struct {
-	TotalCount int32 `json:"total_count"`
+	TotalCount int64 `json:"total_count"`
 }
 
 type DealResponse struct {
@@ -36,7 +36,7 @@ type DealResponse struct {
 
 type GetDealOpts struct {
 	// 取引先ID
-	PartnerID int32 `url:"partner_id,omitempty"`
+	PartnerID int64 `url:"partner_id,omitempty"`
 	// 決済状況 (未決済: unsettled, 完了: settled)
 	Status string `url:"status,omitempty"`
 	// 収支区分 (収入: income, 支出: expense)
@@ -47,15 +47,15 @@ type GetDealOpts struct {
 	EndIssueDate string `url:"end_issue_date,omitempty"`
 	// 取引の債権債務行の表示（without: 表示しない(デフォルト), with: 表示する）
 	Accruals string `url:"accruals,omitempty"`
-	Offset   uint32 `url:"offset,omitempty"`
-	Limit    uint32 `url:"limit,omitempty"`
+	Offset   int64  `url:"offset,omitempty"`
+	Limit    int64  `url:"limit,omitempty"`
 }
 
 type Deal struct {
 	// 取引ID
-	ID uint64 `json:"id"`
+	ID int64 `json:"id"`
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 発生日 (yyyy-mm-dd)
 	IssueDate string `json:"issue_date"`
 	// 支払期日 (yyyy-mm-dd)
@@ -67,7 +67,7 @@ type Deal struct {
 	// 収支区分 (収入: income, 支出: expense)
 	Type *string `json:"type,omitempty"`
 	// 取引先ID
-	PartnerID int32 `json:"partner_id"`
+	PartnerID int64 `json:"partner_id"`
 	// 取引先コード
 	PartnerCode *string `json:"partner_code,omitempty"`
 	// 管理番号
@@ -85,36 +85,36 @@ type Deal struct {
 }
 
 type DealDetails struct {
-	ID uint64 `json:"id"`
+	ID int64 `json:"id"`
 	// 税区分コード
-	TaxCode int32 `json:"tax_code"`
+	TaxCode int64 `json:"tax_code"`
 	// 勘定科目ID
-	AccountItemID int32 `json:"account_item_id"`
+	AccountItemID int64 `json:"account_item_id"`
 	// 取引金額（税込で指定してください）
 	Amount int64 `json:"amount"`
 	// 品目ID
-	ItemID *int32 `json:"item_id,omitempty"`
+	ItemID *int64 `json:"item_id,omitempty"`
 	// 部門ID
-	SectionID *int32 `json:"section_id,omitempty"`
+	SectionID *int64 `json:"section_id,omitempty"`
 	// メモタグID
-	TagIDs *[]int32 `json:"tag_ids,omitempty"`
+	TagIDs *[]int64 `json:"tag_ids,omitempty"`
 	// セグメント１ID
-	Segment1TagID *int32 `json:"segment_1_tag_id,omitempty"`
+	Segment1TagID *int64 `json:"segment_1_tag_id,omitempty"`
 	// セグメント２ID
-	Segment2TagID *int32 `json:"segment_2_tag_id,omitempty"`
+	Segment2TagID *int64 `json:"segment_2_tag_id,omitempty"`
 	// セグメント３ID
-	Segment3TagID *int32 `json:"segment_3_tag_id,omitempty"`
+	Segment3TagID *int64 `json:"segment_3_tag_id,omitempty"`
 	// 備考
 	Description *string `json:"description,omitempty"`
 	// 消費税額（指定しない場合は自動で計算されます）
-	Vat *int32 `json:"vat,omitempty"`
+	Vat *int64 `json:"vat,omitempty"`
 	// 貸借（貸方: credit, 借方: debit）
 	EntrySide string `json:"entry_side"`
 }
 
 type DealRenews struct {
 	// +更新行ID
-	ID uint64 `json:"id"`
+	ID int64 `json:"id"`
 	// 更新日 (yyyy-mm-dd)
 	UpdateDate string `json:"update_date"`
 	// +更新の対象行ID
@@ -127,20 +127,20 @@ type DealRenews struct {
 
 type DealPayments struct {
 	// 取引行ID
-	ID uint64 `json:"id"`
+	ID int64 `json:"id"`
 	// 支払日
 	Date string `json:"date"`
 	// 口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet, プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）: private_account_item)
 	FromWalletableType string `json:"from_walletable_type,omitempty"`
 	// 口座ID（from_walletable_typeがprivate_account_itemの場合は勘定科目ID）
-	FromWalletableID int32 `json:"from_walletable_id,omitempty"`
+	FromWalletableID int64 `json:"from_walletable_id,omitempty"`
 	// 支払金額
 	Amount int64 `json:"amount"`
 }
 
 type DealReceipts struct {
 	// 証憑ID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// ステータス(unconfirmed:確認待ち、confirmed:確認済み、deleted:削除済み、ignored:無視)
 	Status string `json:"status"`
 	// メモ
@@ -160,7 +160,7 @@ type DealReceipts struct {
 
 type DealUser struct {
 	// ユーザーID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// メールアドレス
 	Email string `json:"email"`
 	// 表示名
@@ -173,11 +173,11 @@ type DealCreateParams struct {
 	// 収支区分 (収入: income, 支出: expense)
 	Type string `json:"type"`
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 支払期日(yyyy-mm-dd)
 	DueDate *string `json:"due_date,omitempty"`
 	// 取引先ID
-	PartnerID *int32 `json:"partner_id,omitempty"`
+	PartnerID *int64 `json:"partner_id,omitempty"`
 	// 取引先コード
 	PartnerCode *string `json:"partner_code,omitempty"`
 	// 管理番号
@@ -186,39 +186,39 @@ type DealCreateParams struct {
 	// 支払行一覧（配列）：未指定の場合、未決済の取引を作成します。
 	Payments *[]DealCreateParamsPayments `json:"payments,omitempty"`
 	// 証憑ファイルID（配列）
-	ReceiptIDs *[]int32 `json:"receipt_ids,omitempty"`
+	ReceiptIDs *[]int64 `json:"receipt_ids,omitempty"`
 }
 
 type DealCreateParamsDetails struct {
 	// 税区分コード
-	TaxCode int32 `json:"tax_code"`
+	TaxCode int64 `json:"tax_code"`
 	// 勘定科目ID
-	AccountItemID int32 `json:"account_item_id"`
+	AccountItemID int64 `json:"account_item_id"`
 	// 取引金額（税込で指定してください）
 	Amount int64 `json:"amount"`
 	// 品目ID
-	ItemID *int32 `json:"item_id,omitempty"`
+	ItemID *int64 `json:"item_id,omitempty"`
 	// 部門ID
-	SectionID *int32 `json:"section_id,omitempty"`
+	SectionID *int64 `json:"section_id,omitempty"`
 	// メモタグID
-	TagIDs *[]int32 `json:"tag_ids,omitempty"`
+	TagIDs *[]int64 `json:"tag_ids,omitempty"`
 	// セグメント１ID
-	Segment1TagID *int32 `json:"segment_1_tag_id,omitempty"`
+	Segment1TagID *int64 `json:"segment_1_tag_id,omitempty"`
 	// セグメント２ID
-	Segment2TagID *int32 `json:"segment_2_tag_id,omitempty"`
+	Segment2TagID *int64 `json:"segment_2_tag_id,omitempty"`
 	// セグメント３ID
-	Segment3TagID *int32 `json:"segment_3_tag_id,omitempty"`
+	Segment3TagID *int64 `json:"segment_3_tag_id,omitempty"`
 	// 備考
 	Description *string `json:"description,omitempty"`
 	// 消費税額（指定しない場合は自動で計算されます）
-	Vat *int32 `json:"vat,omitempty"`
+	Vat *int64 `json:"vat,omitempty"`
 }
 
 type DealCreateParamsPayments struct {
 	// 支払金額：payments指定時は必須
 	Amount int64 `json:"amount"`
 	// 口座ID（from_walletable_typeがprivate_account_itemの場合は勘定科目ID）：payments指定時は必須
-	FromWalletableID int32 `json:"from_walletable_id"`
+	FromWalletableID int64 `json:"from_walletable_id"`
 	// 口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet, プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）: private_account_item)：payments指定時は必須
 	FromWalletableType string `json:"from_walletable_type"`
 	// 支払日：payments指定時は必須
@@ -231,49 +231,49 @@ type DealUpdateParams struct {
 	// 収支区分 (収入: income, 支出: expense)
 	Type string `json:"type"`
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 支払期日(yyyy-mm-dd)
 	DueDate *string `json:"due_date,omitempty"`
 	// 取引先ID
-	PartnerID *int32 `json:"partner_id,omitempty"`
+	PartnerID *int64 `json:"partner_id,omitempty"`
 	// 取引先コード
 	PartnerCode *string `json:"partner_code,omitempty"`
 	// 管理番号
 	RefNumber *string                   `json:"ref_number,omitempty"`
 	Details   []DealUpdateParamsDetails `json:"details"`
 	// 証憑ファイルID（配列）
-	ReceiptIDs []int32 `json:"receipt_ids,omitempty"`
+	ReceiptIDs []int64 `json:"receipt_ids,omitempty"`
 }
 
 type DealUpdateParamsDetails struct {
 	// 取引行ID: 既存取引行を更新する場合に指定します。IDを指定しない取引行は、新規行として扱われ追加されます。また、detailsに含まれない既存の取引行は削除されます。更新後も残したい行は、必ず取引行IDを指定してdetailsに含めてください。
-	ID *uint64 `json:"id,omitempty"`
+	ID *int64 `json:"id,omitempty"`
 	// 税区分コード
-	TaxCode int32 `json:"tax_code"`
+	TaxCode int64 `json:"tax_code"`
 	// 勘定科目ID
-	AccountItemID int32 `json:"account_item_id"`
+	AccountItemID int64 `json:"account_item_id"`
 	// 取引金額（税込で指定してください）
 	Amount int64 `json:"amount"`
 	// 品目ID
-	ItemID *int32 `json:"item_id,omitempty"`
+	ItemID *int64 `json:"item_id,omitempty"`
 	// 部門ID
-	SectionID *int32 `json:"section_id,omitempty"`
+	SectionID *int64 `json:"section_id,omitempty"`
 	// メモタグID
-	TagIDs *[]int32 `json:"tag_ids,omitempty"`
+	TagIDs *[]int64 `json:"tag_ids,omitempty"`
 	// セグメント１ID
-	Segment1TagID *int32 `json:"segment_1_tag_id,omitempty"`
+	Segment1TagID *int64 `json:"segment_1_tag_id,omitempty"`
 	// セグメント２ID
-	Segment2TagID *int32 `json:"segment_2_tag_id,omitempty"`
+	Segment2TagID *int64 `json:"segment_2_tag_id,omitempty"`
 	// セグメント３ID
-	Segment3TagID *int32 `json:"segment_3_tag_id,omitempty"`
+	Segment3TagID *int64 `json:"segment_3_tag_id,omitempty"`
 	// 備考
 	Description *string `json:"description,omitempty"`
 	// 消費税額（指定しない場合は自動で計算されます）
-	Vat *int32 `json:"vat,omitempty"`
+	Vat *int64 `json:"vat,omitempty"`
 }
 
 func (c *Client) GetDeals(ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, opts GetDealOpts) (*DealsResponse, *oauth2.Token, error) {
+	companyID int64, opts GetDealOpts) (*DealsResponse, *oauth2.Token, error) {
 	var result DealsResponse
 
 	v, err := query.Values(opts)
@@ -291,7 +291,7 @@ func (c *Client) GetDeals(ctx context.Context, oauth2Token *oauth2.Token,
 
 func (c *Client) GetDeal(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, dealID uint64, opts GetDealOpts,
+	companyID int64, dealID int64, opts GetDealOpts,
 ) (*Deal, *oauth2.Token, error) {
 	var result DealResponse
 
@@ -321,7 +321,7 @@ func (c *Client) CreateDeal(
 
 func (c *Client) UpdateDeal(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	dealID uint64, params DealUpdateParams,
+	dealID int64, params DealUpdateParams,
 ) (*Deal, *oauth2.Token, error) {
 	var result DealResponse
 	oauth2Token, err := c.call(ctx, path.Join(APIPathDeals, fmt.Sprint(dealID)), http.MethodPut, oauth2Token, nil, params, &result)
@@ -333,7 +333,7 @@ func (c *Client) UpdateDeal(
 
 func (c *Client) DestroyDeal(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, dealID uint64,
+	companyID int64, dealID int64,
 ) (*oauth2.Token, error) {
 	v, err := query.Values(nil)
 	if err != nil {

--- a/examples/file/main.go
+++ b/examples/file/main.go
@@ -37,7 +37,7 @@ func main() {
 		log.Fatal(err)
 	}
 	params := freee.CreateReceiptParams{
-		CompanyID: int32(companyID),
+		CompanyID: int64(companyID),
 		Receipt:   f,
 	}
 	resp, token, err := client.CreateReceipt(ctx, token, params, filepath.Base(file))

--- a/invoices.go
+++ b/invoices.go
@@ -69,9 +69,9 @@ type InvoiceResponse struct {
 
 type GetInvoiceOpts struct {
 	// 事業所ID
-	CompanyID int32 `url:"company_id"`
+	CompanyID int64 `url:"company_id"`
 	// 取引先IDで絞込
-	PartnerID int32 `url:"partner_id,omitempty"`
+	PartnerID int64 `url:"partner_id,omitempty"`
 	// 取引先コードで絞込
 	PartnerCode string `url:"partner_code,omitempty"`
 	// 請求日の開始日(yyyy-mm-dd)
@@ -91,20 +91,20 @@ type GetInvoiceOpts struct {
 	// 入金ステータス (unsettled: 入金待ち, settled: 入金済み)
 	PaymentStatus string `url:"payment_status,omitempty"`
 	// 取得レコードのオフセット (デフォルト: 0)
-	Offset uint32 `url:"offset,omitempty"`
+	Offset int64 `url:"offset,omitempty"`
 	// 取得レコードの件数 (デフォルト: 20, 最大: 100)
-	Limit uint32 `url:"limit,omitempty"`
+	Limit int64 `url:"limit,omitempty"`
 }
 
 type Invoice struct {
 	// 請求書ID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 請求日 (yyyy-mm-dd)
 	IssueDate string `json:"issue_date"`
 	// 取引先ID
-	PartnerID int32 `json:"partner_id"`
+	PartnerID int64 `json:"partner_id"`
 	// 取引先コード
 	PartnerCode *string `json:"partner_code,omitempty"`
 	// 請求書番号
@@ -114,11 +114,11 @@ type Invoice struct {
 	// 期日 (yyyy-mm-dd)
 	DueDate *string `json:"due_date,omitempty"`
 	// 合計金額
-	TotalAmount int32 `json:"total_amount"`
+	TotalAmount int64 `json:"total_amount"`
 	// 合計税額
-	TotalVat int32 `json:"total_vat"`
+	TotalVat int64 `json:"total_vat"`
 	// 小計
-	SubTotal int32 `json:"sub_total"`
+	SubTotal int64 `json:"sub_total"`
 	// 売上計上日
 	BookingDate *string `json:"booking_date,omitempty"`
 	// 概要
@@ -148,7 +148,7 @@ type Invoice struct {
 	// 取引先郵便番号
 	PartnerZipcode *string `json:"partner_zipcode,omitempty"`
 	// 取引先都道府県コード（-1: 設定しない、0:北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄
-	PartnerPrefectureCode *int32 `json:"partner_prefecture_code,omitempty"`
+	PartnerPrefectureCode *int64 `json:"partner_prefecture_code,omitempty"`
 	// 取引先都道府県
 	PartnerPrefectureName *string `json:"partner_prefecture_name,omitempty"`
 	// 取引先市区町村・番地
@@ -162,7 +162,7 @@ type Invoice struct {
 	// 郵便番号
 	CompanyZipcode *string `json:"company_zipcode,omitempty"`
 	// 都道府県コード（-1: 設定しない、0:北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄
-	CompanyPrefectureCode *int32 `json:"company_prefecture_code,omitempty"`
+	CompanyPrefectureCode *int64 `json:"company_prefecture_code,omitempty"`
 	// 都道府県
 	CompanyPrefectureName *string `json:"company_prefecture_name,omitempty"`
 	// 市区町村・番地
@@ -192,7 +192,7 @@ type Invoice struct {
 	// 請求書の消費税計算方法(inclusive: 内税, exclusive: 外税)
 	TaxEntryMethod string `json:"tax_entry_method"`
 	// 取引ID (invoice_statusがsubmitted, unsubmittedの時IDが表示されます)
-	DealID *uint64 `json:"deal_id,omitempty"`
+	DealID *int64 `json:"deal_id,omitempty"`
 	// 請求内容
 	InvoiceContents       []InvoiceContent `json:"invoice_contents"`
 	TotalAmountPerVatRate struct {
@@ -210,14 +210,14 @@ type Invoice struct {
 	//
 	// [見積書・納品書を納品書・請求書に変換する](https://support.freee.co.jp/hc/ja/articles/203318410#1-2)
 	// [複数の見積書・納品書から合算請求書を作成する](https://support.freee.co.jp/hc/ja/articles/209076226)
-	RelatedQuotationIDs []int32 `json:"related_quotation_ids,omitempty"`
+	RelatedQuotationIDs []int64 `json:"related_quotation_ids,omitempty"`
 }
 
 type InvoiceContent struct {
 	// 請求内容ID
-	ID uint32 `json:"id"`
+	ID int64 `json:"id"`
 	// 順序
-	Order *uint32 `json:"order,omitempty"`
+	Order *int64 `json:"order,omitempty"`
 	// 行の種類
 	Type string `json:"type"`
 	// 数量
@@ -236,27 +236,27 @@ type InvoiceContent struct {
 	//   - vat: 消費税の金額
 	Amount int64 `json:"amount"`
 	// 消費税額
-	Vat int32 `json:"vat"`
+	Vat int64 `json:"vat"`
 	// 軽減税率税区分（true: 対象、false: 対象外）
 	ReducedVat bool `json:"reduced_vat"`
 	// 備考
 	Description *string `json:"description,omitempty"`
 	// 勘定科目ID
-	AccountItemID int32 `json:"account_item_id"`
+	AccountItemID int64 `json:"account_item_id"`
 	// 勘定科目名
 	AccountItemName string `json:"account_item_name"`
 	// 税区分コード
-	TaxCode int32 `json:"tax_code"`
+	TaxCode int64 `json:"tax_code"`
 	// 品目ID
-	ItemID *int32 `json:"item_id,omitempty"`
+	ItemID *int64 `json:"item_id,omitempty"`
 	// 品目
 	ItemName *string `json:"item_name,omitempty"`
 	// 部門ID
-	SectionID *int32 `json:"section_id,omitempty"`
+	SectionID *int64 `json:"section_id,omitempty"`
 	// 部門
 	SectionName *string `json:"section_name,omitempty"`
 	// メモタグID
-	TagIDs []int32 `json:"tag_ids"`
+	TagIDs []int64 `json:"tag_ids"`
 	// メモタグ
 	TagNames []string `json:"tag_names"`
 	// セグメント１ID
@@ -275,11 +275,11 @@ type InvoiceContent struct {
 
 type InvoiceCreateParams struct {
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 請求日 (yyyy-mm-dd)
 	IssueDate *string `json:"issue_date,omitempty"`
 	// 取引先ID
-	PartnerID *int32 `json:"partner_id,omitempty"`
+	PartnerID *int64 `json:"partner_id,omitempty"`
 	// 取引先コード
 	PartnerCode *string `json:"partner_code,omitempty"`
 	// 請求書番号 (デフォルト: 自動採番されます)
@@ -310,7 +310,7 @@ type InvoiceCreateParams struct {
 	// 取引先郵便番号 (デフォルトはpartner_idもしくはpartner_codeで指定された取引先設定情報が補完されます)
 	PartnerZipcode *string `json:"partner_zipcode,omitempty"`
 	// 取引先都道府県コード（0:北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄) (デフォルトはpartner_idもしくはpartner_codeで指定された取引先設定情報が補完されます)
-	PartnerPrefectureCode *int32 `json:"partner_prefecture_code,omitempty"`
+	PartnerPrefectureCode *int64 `json:"partner_prefecture_code,omitempty"`
 	// 取引先市区町村・番地 (デフォルトはpartner_idもしくはpartner_codeで指定された取引先設定情報が補完されます)
 	PartnerAddress1 *string `json:"partner_address1,omitempty"`
 	// 取引先建物名・部屋番号など (デフォルトはpartner_idもしくはpartner_codeで指定された取引先設定情報が補完されます)
@@ -320,7 +320,7 @@ type InvoiceCreateParams struct {
 	// 郵便番号 (デフォルトは事業所設定情報が補完されます)
 	CompanyZipcode *string `json:"company_zipcode,omitempty"`
 	// 都道府県コード（0:北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄) (デフォルトは事業所設定情報が補完されます)
-	CompanyPrefectureCode *int32 `json:"company_prefecture_code,omitempty"`
+	CompanyPrefectureCode *int64 `json:"company_prefecture_code,omitempty"`
 	// 市区町村・番地 (デフォルトは事業所設定情報が補完されます)
 	CompanyAddress1 *string `json:"company_address1,omitempty"`
 	// 建物名・部屋番号など (デフォルトは事業所設定情報が補完されます)
@@ -355,7 +355,7 @@ type InvoiceCreateParams struct {
 
 type InvoiceCreateParamsInvoiceContent struct {
 	// 順序
-	Order uint32 `json:"order"`
+	Order int64 `json:"order"`
 	// 行の種類
 	//
 	// - normal、discountを指定する場合、account_item_id,tax_codeとunit_priceが必須となります。
@@ -368,19 +368,19 @@ type InvoiceCreateParamsInvoiceContent struct {
 	// 単価 (tax_entry_method: inclusiveの場合は税込価格、tax_entry_method: exclusiveの場合は税抜価格となります)
 	UnitPrice json.Number `json:"unit_price"`
 	// 消費税額
-	Vat *int32 `json:"vat,omitempty"`
+	Vat *int64 `json:"vat,omitempty"`
 	// 備考
 	Description *string `json:"description,omitempty"`
 	// 勘定科目ID
-	AccountItemID int32 `json:"account_item_id"`
+	AccountItemID int64 `json:"account_item_id"`
 	// 税区分コード
-	TaxCode int32 `json:"tax_code"`
+	TaxCode int64 `json:"tax_code"`
 	// 品目ID
-	ItemID *int32 `json:"item_id,omitempty"`
+	ItemID *int64 `json:"item_id,omitempty"`
 	// 部門ID
-	SectionID *int32 `json:"section_id,omitempty"`
+	SectionID *int64 `json:"section_id,omitempty"`
 	// メモタグID
-	TagIDs *[]int32 `json:"tag_ids,omitempty"`
+	TagIDs *[]int64 `json:"tag_ids,omitempty"`
 	// セグメント１ID
 	Segment1TagID *int64 `json:"segment_1_tag_id,omitempty"`
 	// セグメント２ID
@@ -391,11 +391,11 @@ type InvoiceCreateParamsInvoiceContent struct {
 
 type InvoiceUpdateParams struct {
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 請求日 (yyyy-mm-dd)
 	IssueDate *string `json:"issue_date,omitempty"`
 	// 取引先ID
-	PartnerID *int32 `json:"partner_id,omitempty"`
+	PartnerID *int64 `json:"partner_id,omitempty"`
 	// 取引先コード
 	PartnerCode *string `json:"partner_code,omitempty"`
 	// 請求書番号 (デフォルト: 自動採番されます)
@@ -426,7 +426,7 @@ type InvoiceUpdateParams struct {
 	// 取引先郵便番号 (デフォルトはpartner_idもしくはpartner_codeで指定された取引先設定情報が補完されます)
 	PartnerZipcode *string `json:"partner_zipcode,omitempty"`
 	// 取引先都道府県コード（0:北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄) (デフォルトはpartner_idもしくはpartner_codeで指定された取引先設定情報が補完されます)
-	PartnerPrefectureCode *int32 `json:"partner_prefecture_code,omitempty"`
+	PartnerPrefectureCode *int64 `json:"partner_prefecture_code,omitempty"`
 	// 取引先市区町村・番地 (デフォルトはpartner_idもしくはpartner_codeで指定された取引先設定情報が補完されます)
 	PartnerAddress1 *string `json:"partner_address1,omitempty"`
 	// 取引先建物名・部屋番号など (デフォルトはpartner_idもしくはpartner_codeで指定された取引先設定情報が補完されます)
@@ -436,7 +436,7 @@ type InvoiceUpdateParams struct {
 	// 郵便番号 (デフォルトは事業所設定情報が補完されます)
 	CompanyZipcode *string `json:"company_zipcode,omitempty"`
 	// 都道府県コード（0:北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄) (デフォルトは事業所設定情報が補完されます)
-	CompanyPrefectureCode *int32 `json:"company_prefecture_code,omitempty"`
+	CompanyPrefectureCode *int64 `json:"company_prefecture_code,omitempty"`
 	// 市区町村・番地 (デフォルトは事業所設定情報が補完されます)
 	CompanyAddress1 *string `json:"company_address1,omitempty"`
 	// 建物名・部屋番号など (デフォルトは事業所設定情報が補完されます)
@@ -471,9 +471,9 @@ type InvoiceUpdateParams struct {
 
 type InvoiceUpdateParamsInvoiceContent struct {
 	// 請求内容ID
-	ID *uint32 `json:"id,omitempty"`
+	ID *int64 `json:"id,omitempty"`
 	// 順序
-	Order uint32 `json:"order"`
+	Order int64 `json:"order"`
 	// 行の種類
 	//
 	// - normal、discountを指定する場合、account_item_id,tax_codeとunit_priceが必須となります。
@@ -486,19 +486,19 @@ type InvoiceUpdateParamsInvoiceContent struct {
 	// 単価 (tax_entry_method: inclusiveの場合は税込価格、tax_entry_method: exclusiveの場合は税抜価格となります)
 	UnitPrice json.Number `json:"unit_price"`
 	// 消費税額
-	Vat *int32 `json:"vat,omitempty"`
+	Vat *int64 `json:"vat,omitempty"`
 	// 備考
 	Description *string `json:"description,omitempty"`
 	// 勘定科目ID
-	AccountItemID int32 `json:"account_item_id"`
+	AccountItemID int64 `json:"account_item_id"`
 	// 税区分コード
-	TaxCode int32 `json:"tax_code"`
+	TaxCode int64 `json:"tax_code"`
 	// 品目ID
-	ItemID *int32 `json:"item_id,omitempty"`
+	ItemID *int64 `json:"item_id,omitempty"`
 	// 部門ID
-	SectionID *int32 `json:"section_id,omitempty"`
+	SectionID *int64 `json:"section_id,omitempty"`
 	// メモタグID
-	TagIDs *[]int32 `json:"tag_ids,omitempty"`
+	TagIDs *[]int64 `json:"tag_ids,omitempty"`
 	// セグメント１ID
 	Segment1TagID *int64 `json:"segment_1_tag_id,omitempty"`
 	// セグメント２ID
@@ -509,7 +509,7 @@ type InvoiceUpdateParamsInvoiceContent struct {
 
 func (c *Client) GetInvoices(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, opts GetInvoiceOpts,
+	companyID int64, opts GetInvoiceOpts,
 ) (*InvoicesResponse, *oauth2.Token, error) {
 	var result InvoicesResponse
 	v, err := query.Values(opts)
@@ -526,7 +526,7 @@ func (c *Client) GetInvoices(
 
 func (c *Client) GetInvoice(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, invoiceID int32, opts GetInvoiceOpts,
+	companyID int64, invoiceID int64, opts GetInvoiceOpts,
 ) (*Invoice, *oauth2.Token, error) {
 	var result InvoiceResponse
 	v, err := query.Values(opts)
@@ -555,7 +555,7 @@ func (c *Client) CreateInvoice(
 
 func (c *Client) UpdateInvoice(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	invoiceID int32, params InvoiceUpdateParams,
+	invoiceID int64, params InvoiceUpdateParams,
 ) (*Invoice, *oauth2.Token, error) {
 	var result InvoiceResponse
 	oauth2Token, err := c.call(ctx, path.Join(APIPathInvoices, fmt.Sprint(invoiceID)), http.MethodPut, oauth2Token, nil, params, &result)
@@ -567,7 +567,7 @@ func (c *Client) UpdateInvoice(
 
 func (c *Client) DestroyInvoice(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, invoiceID int32,
+	companyID int64, invoiceID int64,
 ) (*oauth2.Token, error) {
 	v, err := query.Values(nil)
 	if err != nil {

--- a/items.go
+++ b/items.go
@@ -24,9 +24,9 @@ type ItemResponse struct {
 
 type Item struct {
 	// 品目ID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 品目名 (30文字以内)
 	Name string `json:"name"`
 	// 更新日(yyyy-mm-dd)
@@ -42,13 +42,13 @@ type Item struct {
 }
 
 type GetItemsOpts struct {
-	Offset uint32 `url:"offset,omitempty"`
-	Limit  uint32 `url:"limit,omitempty"`
+	Offset int64 `url:"offset,omitempty"`
+	Limit  int64 `url:"limit,omitempty"`
 }
 
 type ItemParams struct {
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 品目名 (30文字以内)
 	Name string `json:"name"`
 	// ショートカット１ (20文字以内)
@@ -61,7 +61,7 @@ type ItemParams struct {
 
 func (c *Client) GetItems(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, opts GetItemsOpts,
+	companyID int64, opts GetItemsOpts,
 ) (*Items, *oauth2.Token, error) {
 	var result Items
 
@@ -93,7 +93,7 @@ func (c *Client) CreateItem(
 func (c *Client) UpdateItem(
 	ctx context.Context, oauth2Token *oauth2.Token,
 	params ItemParams,
-	itemID uint32,
+	itemID int64,
 ) (*Item, *oauth2.Token, error) {
 	var result ItemResponse
 	oauth2Token, err := c.call(ctx, path.Join(APIPathItems, fmt.Sprint(itemID)), http.MethodPut, oauth2Token, nil, params, &result)
@@ -105,7 +105,7 @@ func (c *Client) UpdateItem(
 
 func (c *Client) DestroyItem(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, itemID int32,
+	companyID int64, itemID int64,
 ) (*oauth2.Token, error) {
 	v, err := query.Values(nil)
 	if err != nil {

--- a/manual_journals.go
+++ b/manual_journals.go
@@ -27,9 +27,9 @@ type ManualJournalResponse struct {
 
 type ManualJournal struct {
 	// 振替伝票ID
-	ID uint64 `json:"id"`
+	ID int64 `json:"id"`
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 発生日 (yyyy-mm-dd)
 	IssueDate string `json:"issue_date"`
 	// 決算整理仕訳フラグ（falseまたは未指定の場合: 日常仕訳）
@@ -39,20 +39,20 @@ type ManualJournal struct {
 	// 貸借行一覧（配列）: 貸借合わせて100行まで登録できます。
 	Details []ManualJournalDetails `json:"details"`
 	// 証憑ファイルID（ファイルボックスのファイルID）（配列）
-	ReceiptIDs []uint64 `json:"receipt_ids"`
+	ReceiptIDs []int64 `json:"receipt_ids"`
 }
 
 type ManualJournalDetails struct {
 	// 貸借行ID
-	ID uint64 `json:"id"`
+	ID int64 `json:"id"`
 	// 貸借(貸方: credit, 借方: debit)
 	EntrySide string `json:"entry_side"`
 	// 勘定科目ID
-	AccountItemID int32 `json:"account_item_id"`
+	AccountItemID int64 `json:"account_item_id"`
 	// 税区分コード
-	TaxCode int32 `json:"tax_code"`
+	TaxCode int64 `json:"tax_code"`
 	// 取引先ID
-	PartnerID *int32 `json:"partner_id"`
+	PartnerID *int64 `json:"partner_id"`
 	// 取引先名
 	PartnerName *string `json:"partner_name"`
 	// 取引先コード
@@ -60,38 +60,38 @@ type ManualJournalDetails struct {
 	// 正式名称（255文字以内）
 	PartnerLongName *string `json:"partner_long_name"`
 	// 品目ID
-	ItemID *int32 `json:"item_id"`
+	ItemID *int64 `json:"item_id"`
 	// 品目
 	ItemName *string `json:"item_name"`
 	// 部門ID
-	SectionID *int32 `json:"section_id"`
+	SectionID *int64 `json:"section_id"`
 	// 部門
 	SectionName *string  `json:"section_name"`
-	TagIDs      []int32  `json:"tag_ids"`
+	TagIDs      []int64  `json:"tag_ids"`
 	TagNames    []string `json:"tag_names"`
 	// セグメント１ID
-	Segment1TagID int32 `json:"segment_1_tag_id,omitempty"`
+	Segment1TagID int64 `json:"segment_1_tag_id,omitempty"`
 	// セグメント１ID
 	Segment1TagName *string `json:"segment_1_tag_name,omitempty"`
 	// セグメント２ID
-	Segment2TagID int32 `json:"segment_2_tag_id,omitempty"`
+	Segment2TagID int64 `json:"segment_2_tag_id,omitempty"`
 	// セグメント２
 	Segment2TagName *string `json:"segment_2_tag_name,omitempty"`
 	// セグメント３ID
-	Segment3TagID int32 `json:"segment_3_tag_id,omitempty"`
+	Segment3TagID int64 `json:"segment_3_tag_id,omitempty"`
 	// セグメント３
 	Segment3TagName *string `json:"segment_3_tag_name,omitempty"`
 	// 金額（税込で指定してください）
-	Amount int32 `json:"amount"`
+	Amount int64 `json:"amount"`
 	// 消費税額（指定しない場合は自動で計算されます）
-	Vat *int32 `json:"vat,omitempty"`
+	Vat *int64 `json:"vat,omitempty"`
 	// 備考
 	Description string `json:"description"`
 }
 
 type CreateManualJournalParams struct {
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 発生日 (yyyy-mm-dd)
 	IssueDate string `json:"issue_date"`
 	// 仕訳番号
@@ -100,82 +100,82 @@ type CreateManualJournalParams struct {
 	Adjustment                       bool                              `json:"adjustment,omitempty"`
 	CreateManualJournalParamsDetails []CreateManualJournalParamsDetail `json:"details"`
 	// 証憑ファイルID（ファイルボックスのファイルID）（配列）
-	ReceiptIDs []uint64 `json:"receipt_ids,omitempty"`
+	ReceiptIDs []int64 `json:"receipt_ids,omitempty"`
 }
 
 type CreateManualJournalParamsDetail struct {
 	// 貸借（貸方: credit, 借方: debit）
 	EntrySide string `json:"entry_side"`
 	// 税区分コード
-	TaxCode int32 `json:"tax_code"`
+	TaxCode int64 `json:"tax_code"`
 	// 勘定科目ID
-	AccountItemID int32 `json:"account_item_id"`
+	AccountItemID int64 `json:"account_item_id"`
 	// 取引金額（税込で指定してください）
-	Amount uint64 `json:"amount"`
+	Amount int64 `json:"amount"`
 	// 消費税額（指定しない場合は自動で計算されます）
-	Vat *int32 `json:"vat,omitempty"`
+	Vat *int64 `json:"vat,omitempty"`
 	// 取引先ID
-	PartnerID int32 `json:"partner_id,omitempty"`
+	PartnerID int64 `json:"partner_id,omitempty"`
 	// 取引先コード
 	PartnerCode string `json:"partner_code,omitempty"`
 	// 品目ID
-	ItemID int32 `json:"item_id,omitempty"`
+	ItemID int64 `json:"item_id,omitempty"`
 	// 部門ID
-	SectionID int32 `json:"section_id,omitempty"`
+	SectionID int64 `json:"section_id,omitempty"`
 	// メモタグID
-	TagIDs []int32 `json:"tag_ids,omitempty"`
+	TagIDs []int64 `json:"tag_ids,omitempty"`
 	// セグメント１ID
-	Segment1TagID uint64 `json:"segment_1_tag_id,omitempty"`
+	Segment1TagID int64 `json:"segment_1_tag_id,omitempty"`
 	// セグメント２ID
-	Segment2TagID uint64 `json:"segment_2_tag_id,omitempty"`
+	Segment2TagID int64 `json:"segment_2_tag_id,omitempty"`
 	// セグメント３ID
-	Segment3TagID uint64 `json:"segment_3_tag_id,omitempty"`
+	Segment3TagID int64 `json:"segment_3_tag_id,omitempty"`
 	// 備考
 	Description string `json:"description,omitempty"`
 }
 
 type UpdateManualJournalParams struct {
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 発生日 (yyyy-mm-dd)
 	IssueDate string `json:"issue_date"`
 	// 決算整理仕訳フラグ（falseまたは未指定の場合: 日常仕訳）
 	Adjustment bool                               `json:"adjustment,omitempty"`
 	Details    []UpdateManualJournalParamsDetails `json:"details"`
 	// 証憑ファイルID（ファイルボックスのファイルID）（配列）
-	ReceiptIDs []uint64 `json:"receipt_ids,omitempty"`
+	ReceiptIDs []int64 `json:"receipt_ids,omitempty"`
 }
 
 // ManualJournalUpdateParamsDetails 貸借行一覧（配列）: 貸借合わせて100行まで登録できます。
 type UpdateManualJournalParamsDetails struct {
 	// 貸借行ID: 既存貸借行を更新または削除する場合に指定します。IDを指定しない貸借行は、新規行として扱われ追加されます。
-	ID uint64 `json:"id,omitempty"`
+	ID int64 `json:"id,omitempty"`
 	// 貸借（貸方: credit, 借方: debit）
 	EntrySide string `json:"entry_side"`
 	// 税区分コード
-	TaxCode int32 `json:"tax_code"`
+	TaxCode int64 `json:"tax_code"`
 	// 勘定科目ID
-	AccountItemID int32 `json:"account_item_id"`
+	AccountItemID int64 `json:"account_item_id"`
 	// 取引金額（税込で指定してください）
-	Amount int32 `json:"amount"`
+	Amount int64 `json:"amount"`
 	// 消費税額（指定しない場合は自動で計算されます）
-	Vat *int32 `json:"vat,omitempty"`
+	Vat *int64 `json:"vat,omitempty"`
 	// 取引先ID
-	PartnerID int32 `json:"partner_id,omitempty"`
+	PartnerID int64 `json:"partner_id,omitempty"`
 	// 取引先コード
 	PartnerCode string `json:"partner_code,omitempty"`
 	// 品目ID
-	ItemID int32 `json:"item_id,omitempty"`
+	ItemID int64 `json:"item_id,omitempty"`
 	// 部門ID
-	SectionID int32 `json:"section_id,omitempty"`
+	SectionID int64 `json:"section_id,omitempty"`
 	// メモタグID
-	TagIDs []int32 `json:"tag_ids,omitempty"`
+	TagIDs []int64 `json:"tag_ids,omitempty"`
 	// セグメント１ID
-	Segment1TagID int32 `json:"segment_1_tag_id,omitempty"`
+	Segment1TagID int64 `json:"segment_1_tag_id,omitempty"`
 	// セグメント２ID
-	Segment2TagID int32 `json:"segment_2_tag_id,omitempty"`
+	Segment2TagID int64 `json:"segment_2_tag_id,omitempty"`
 	// セグメント３ID
-	Segment3TagID int32 `json:"segment_3_tag_id,omitempty"`
+	Segment3TagID int64 `json:"segment_3_tag_id,omitempty"`
 	// 備考
 	Description string `json:"description,omitempty"`
 }
@@ -187,8 +187,8 @@ type GetManualJournalsOpts struct {
 	EndIssueDate string `url:"end_issue_date,omitempty"`
 	// 貸借で絞込 (貸方: credit, 借方: debit)
 	EntrySide string `url:"entry_side,omitempty"`
-	Offset    uint32 `url:"offset,omitempty"`
-	Limit     uint32 `url:"limit,omitempty"`
+	Offset    int64  `url:"offset,omitempty"`
+	Limit     int64  `url:"limit,omitempty"`
 }
 
 func (c *Client) CreateManualJournal(
@@ -221,7 +221,7 @@ func (c *Client) UpdateManualJournal(
 
 func (c *Client) DestroyManualJournal(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, journalID int64,
+	companyID int64, journalID int64,
 ) (*oauth2.Token, error) {
 	v, err := query.Values(nil)
 	if err != nil {
@@ -238,7 +238,7 @@ func (c *Client) DestroyManualJournal(
 
 func (c *Client) GetManualJournal(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, journalID int64, opts GetManualJournalsOpts,
+	companyID int64, journalID int64, opts GetManualJournalsOpts,
 ) (*ManualJournalResponse, *oauth2.Token, error) {
 	var result ManualJournalResponse
 
@@ -258,7 +258,7 @@ func (c *Client) GetManualJournal(
 
 func (c *Client) GetManualJournals(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, opts GetManualJournalsOpts,
+	companyID int64, opts GetManualJournalsOpts,
 ) (*ManualJournalsResponse, *oauth2.Token, error) {
 	var result ManualJournalsResponse
 

--- a/partners.go
+++ b/partners.go
@@ -37,11 +37,11 @@ type PartnerResponse struct {
 
 type Partner struct {
 	// 取引先ID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// 取引先コード
 	Code *string `json:"code,omitempty"`
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 取引先名
 	Name string `json:"name"`
 	// 更新日 (yyyy-mm-dd)
@@ -53,7 +53,7 @@ type Partner struct {
 	// ショートカット2 (20文字以内)
 	Shortcut2 *string `json:"shortcut2,omitempty"`
 	// 事業所種別（null: 未設定、1: 法人、2: 個人）
-	OrgCode *int32 `json:"org_code,omitempty"`
+	OrgCode *int64 `json:"org_code,omitempty"`
 	// 地域（JP: 国内、ZZ:国外）
 	CountryCode string `json:"country_code,omitempty"`
 	// 正式名称（255文字以内）
@@ -69,7 +69,7 @@ type Partner struct {
 	// 担当者 メールアドレス
 	Email *string `json:"email,omitempty"`
 	// 振込元口座ID（一括振込ファイル用）:（未設定の場合は、nullです。）
-	PayerWalletableID *int32 `json:"payer_walletable_id,omitempty"`
+	PayerWalletableID *int64 `json:"payer_walletable_id,omitempty"`
 	// 振込手数料負担（一括振込ファイル用）: (振込元(当方): payer, 振込先(先方): payee)
 	TransferFeeHandlingSide string `json:"transfer_fee_handling_side,omitempty"`
 	// インボイス制度適格請求書発行事業者（true: 対象事業者、false: 非対象事業者）
@@ -88,7 +88,7 @@ type PartnerAddressAttributes struct {
 	// 郵便番号
 	Zipcode *string `json:"zipcode,omitempty"`
 	// 都道府県コード（0:北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄
-	PrefectureCode int32 `json:"prefecture_code,omitempty"`
+	PrefectureCode int64 `json:"prefecture_code,omitempty"`
 	// 市区町村・番地
 	StreetName1 *string `json:"street_name1,omitempty"`
 	// 建物名・部屋番号など
@@ -125,7 +125,7 @@ type PartnerBankAccountAttributes struct {
 
 type CreatePartnerParams struct {
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 取引先名 (255文字以内)
 	Name string `json:"name"`
 	// 取引先コード（取引先コードの利用を有効にしている場合は、codeの指定は必須です。）
@@ -135,7 +135,7 @@ type CreatePartnerParams struct {
 	// ショートカット２ (255文字以内)
 	Shortcut2 string `json:"shortcut2,omitempty"`
 	// 事業所種別（null: 未設定、1: 法人、2: 個人）
-	OrgCode *int32 `json:"org_code,omitempty"`
+	OrgCode *int64 `json:"org_code,omitempty"`
 	// 地域（JP: 国内、ZZ:国外）
 	CountryCode string `json:"country_code,omitempty"`
 	// 正式名称（255文字以内）
@@ -151,7 +151,7 @@ type CreatePartnerParams struct {
 	// 担当者 メールアドレス (255文字以内)
 	Email string `json:"email,omitempty"`
 	// 振込元口座ID（一括振込ファイル用）:（walletableのtypeが'bank_account'のidのみ指定できます。また、未設定にする場合は、nullを指定してください。）
-	PayerWalletableID *int32 `json:"payer_walletable_id,omitempty"`
+	PayerWalletableID *int64 `json:"payer_walletable_id,omitempty"`
 	// 振込手数料負担（一括振込ファイル用）: (振込元(当方): payer, 振込先(先方): payee)
 	TransferFeeHandlingSide string `json:"transfer_fee_handling_side,omitempty"`
 	// インボイス制度適格請求書発行事業者（true: 対象事業者、false: 非対象事業者）
@@ -170,7 +170,7 @@ type CreatePartnerParamsAddressAttributes struct {
 	// 郵便番号（8文字以内）
 	Zipcode string `json:"zipcode,omitempty"`
 	// 都道府県コード（0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄
-	PrefectureCode int32 `json:"prefecture_code,omitempty"`
+	PrefectureCode int64 `json:"prefecture_code,omitempty"`
 	// 市区町村・番地（255文字以内）
 	StreetName1 string `json:"street_name1,omitempty"`
 	// 建物名・部屋番号など（255文字以内）
@@ -207,11 +207,11 @@ type CreatePartnerParamsPartnerBankAccountAttributes struct {
 
 type CreatePartnerParamsPaymentTermAttributes struct {
 	// 締め日（29, 30, 31日の末日を指定する場合は、32を指定してください。）
-	CutoffDay int32 `json:"cutoff_day,omitempty"`
+	CutoffDay int64 `json:"cutoff_day,omitempty"`
 	// 支払月
-	AdditionalMonths int32 `json:"additional_months,omitempty"`
+	AdditionalMonths int64 `json:"additional_months,omitempty"`
 	// 支払日（29, 30, 31日の末日を指定する場合は、32を指定してください。）
-	FixedDay int32 `json:"fixed_day,omitempty"`
+	FixedDay int64 `json:"fixed_day,omitempty"`
 }
 
 func (c *Client) CreatePartner(
@@ -233,7 +233,7 @@ func (c *Client) CreatePartner(
 
 type UpdatePartnerParams struct {
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 取引先名 (255文字以内)
 	Name string `json:"name"`
 	// ショートカット１ (255文字以内)
@@ -241,7 +241,7 @@ type UpdatePartnerParams struct {
 	// ショートカット２ (255文字以内)
 	Shortcut2 string `json:"shortcut2,omitempty"`
 	// 事業所種別（null: 未設定、1: 法人、2: 個人）
-	OrgCode *int32 `json:"org_code,omitempty"`
+	OrgCode *int64 `json:"org_code,omitempty"`
 	// 地域（JP: 国内、ZZ:国外）
 	CountryCode string `json:"country_code,omitempty"`
 	// 正式名称（255文字以内）
@@ -257,7 +257,7 @@ type UpdatePartnerParams struct {
 	// 担当者 メールアドレス (255文字以内)
 	Email string `json:"email,omitempty"`
 	// 振込元口座ID（一括振込ファイル用）:（walletableのtypeが'bank_account'のidのみ指定できます。また、未設定にする場合は、nullを指定してください。）
-	PayerWalletableID *int32 `json:"payer_walletable_id,omitempty"`
+	PayerWalletableID *int64 `json:"payer_walletable_id,omitempty"`
 	// 振込手数料負担（一括振込ファイル用）: (振込元(当方): payer, 振込先(先方): payee)
 	TransferFeeHandlingSide string `json:"transfer_fee_handling_side,omitempty"`
 	// インボイス制度適格請求書発行事業者（true: 対象事業者、false: 非対象事業者）
@@ -274,7 +274,7 @@ type UpdatePartnerParams struct {
 
 func (c *Client) UpdatePartner(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	partnerID uint32, params UpdatePartnerParams,
+	partnerID int64, params UpdatePartnerParams,
 ) (*Partner, *oauth2.Token, error) {
 	var result PartnerResponse
 
@@ -290,14 +290,14 @@ func (c *Client) UpdatePartner(
 }
 
 type GetPartnersOpts struct {
-	Offset  uint32 `url:"offset,omitempty"`
-	Limit   uint32 `url:"limit,omitempty"`
+	Offset  int64  `url:"offset,omitempty"`
+	Limit   int64  `url:"limit,omitempty"`
 	Keyword string `url:"keyword,omitempty"`
 }
 
 func (c *Client) GetPartners(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, opts GetPartnersOpts,
+	companyID int64, opts GetPartnersOpts,
 ) (*Partners, *oauth2.Token, error) {
 	var result Partners
 
@@ -316,7 +316,7 @@ func (c *Client) GetPartners(
 
 func (c *Client) DestroyPartner(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, partnerID int32,
+	companyID int64, partnerID int64,
 ) (*oauth2.Token, error) {
 	v, err := query.Values(nil)
 	if err != nil {

--- a/receipts.go
+++ b/receipts.go
@@ -16,7 +16,7 @@ const (
 
 type CreateReceiptParams struct {
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// メモ (255文字以内)
 	Description string `json:"description,omitempty"`
 	// 取引日 (yyyy-mm-dd)
@@ -35,7 +35,7 @@ type ReceiptResponse struct {
 
 type Receipt struct {
 	// 証憑ID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// ステータス(unconfirmed:確認待ち、confirmed:確認済み、deleted:削除済み、ignored:無視)
 	Status string `json:"status"`
 	// メモ
@@ -57,17 +57,17 @@ type GetReceiptOpts struct {
 	StartDate        string `url:"start_date"`
 	EndDate          string `url:"end_date"`
 	UserName         string `url:"user_name,omitempty"`
-	Number           int32  `url:"number,omitempty"`
+	Number           int64  `url:"number,omitempty"`
 	CommentType      string `url:"comment_type,omitempty"`
 	CommentImportant bool   `url:"comment_important,omitempty"`
 	Category         string `url:"category,omitempty"`
-	Offset           uint32 `url:"offset,omitempty"`
-	Limit            uint32 `url:"limit,omitempty"`
+	Offset           int64  `url:"offset,omitempty"`
+	Limit            int64  `url:"limit,omitempty"`
 }
 
 type UserCreatedReceipt struct {
 	// ユーザーID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// メールアドレス
 	Email string `json:"email"`
 	// 表示名
@@ -93,7 +93,7 @@ func (c *Client) CreateReceipt(
 }
 
 func (c *Client) GetReceipt(
-	ctx context.Context, oauth2Token *oauth2.Token, companyID uint32, receiptID int32,
+	ctx context.Context, oauth2Token *oauth2.Token, companyID int64, receiptID int64,
 ) (*ReceiptResponse, *oauth2.Token, error) {
 	var result ReceiptResponse
 

--- a/sections.go
+++ b/sections.go
@@ -24,9 +24,9 @@ type SectionResponse struct {
 
 type Section struct {
 	// 部門ID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 部門コード
 	Code *string `json:"code,omitempty"`
 	// 部門名 (30文字以内)
@@ -41,7 +41,7 @@ type Section struct {
 
 type SectionParams struct {
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 部門コード（利用を有効にしている場合は必須）
 	Code *string `json:"code,omitempty"`
 	// 部門名 (30文字以内)
@@ -53,12 +53,12 @@ type SectionParams struct {
 	// ショートカット２ (20文字以内)
 	Shortcut2 *string `json:"shortcut2,omitempty"`
 	// 親部門ID (ビジネスプラン以上)
-	ParentID *int32 `json:"parent_id,omitempty"`
+	ParentID *int64 `json:"parent_id,omitempty"`
 }
 
 func (c *Client) GetSections(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32,
+	companyID int64,
 ) (*Sections, *oauth2.Token, error) {
 	var result Sections
 
@@ -89,7 +89,7 @@ func (c *Client) CreateSection(
 
 func (c *Client) UpdateSection(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	sectionID uint32, params SectionParams,
+	sectionID int64, params SectionParams,
 ) (*Section, *oauth2.Token, error) {
 	var result SectionResponse
 	oauth2Token, err := c.call(ctx, path.Join(APIPathSections, fmt.Sprint(sectionID)), http.MethodPut, oauth2Token, nil, params, &result)
@@ -101,7 +101,7 @@ func (c *Client) UpdateSection(
 
 func (c *Client) DestroySection(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, sectionID int32,
+	companyID int64, sectionID int64,
 ) (*oauth2.Token, error) {
 	v, err := query.Values(nil)
 	if err != nil {

--- a/segment_tags.go
+++ b/segment_tags.go
@@ -12,9 +12,9 @@ import (
 
 const (
 	APIPathSegments = "segments"
-	SegmentID1      = uint32(1)
-	SegmentID2      = uint32(2)
-	SegmentID3      = uint32(3)
+	SegmentID1      = int64(1)
+	SegmentID2      = int64(2)
+	SegmentID3      = int64(3)
 )
 
 type SegmentTags struct {
@@ -27,7 +27,7 @@ type SegmentTagResponse struct {
 
 type SegmentTag struct {
 	// セグメントタグID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// セグメントコード（利用を有効にしている場合は必須）
 	Code *string `json:"code,omitempty"`
 	// セグメントタグ名
@@ -42,7 +42,7 @@ type SegmentTag struct {
 
 type SegmentTagParams struct {
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// セグメントコード（利用を有効にしている場合は必須）
 	Code *string `json:"code,omitempty"`
 	// セグメントタグ名 (30文字以内)
@@ -56,13 +56,13 @@ type SegmentTagParams struct {
 }
 
 type GetSegmentTagsOpts struct {
-	Offset uint32 `url:"offset,omitempty"`
-	Limit  uint32 `url:"limit,omitempty"`
+	Offset int64 `url:"offset,omitempty"`
+	Limit  int64 `url:"limit,omitempty"`
 }
 
 func (c *Client) GetSegmentTags(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, segmentID uint32,
+	companyID int64, segmentID int64,
 	opts GetSegmentTagsOpts,
 ) (*SegmentTags, *oauth2.Token, error) {
 	var result SegmentTags
@@ -82,7 +82,7 @@ func (c *Client) GetSegmentTags(
 
 func (c *Client) CreateSegmentTag(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	segmentID uint32, params SegmentTagParams,
+	segmentID int64, params SegmentTagParams,
 ) (*SegmentTag, *oauth2.Token, error) {
 	var result SegmentTagResponse
 	oauth2Token, err := c.call(ctx, path.Join(APIPathSegments, fmt.Sprint(segmentID), "tags"), http.MethodPost, oauth2Token, nil, params, &result)
@@ -94,7 +94,7 @@ func (c *Client) CreateSegmentTag(
 
 func (c *Client) UpdateSegmentTag(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	segmentID uint32, id uint32,
+	segmentID int64, id int64,
 	params SegmentTagParams,
 ) (*SegmentTag, *oauth2.Token, error) {
 	var result SegmentTagResponse
@@ -107,8 +107,8 @@ func (c *Client) UpdateSegmentTag(
 
 func (c *Client) DestroySegmentTag(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32,
-	segmentID uint32, id uint32,
+	companyID int64,
+	segmentID int64, id int64,
 ) (*oauth2.Token, error) {
 	v, err := query.Values(nil)
 	if err != nil {

--- a/tags.go
+++ b/tags.go
@@ -24,9 +24,9 @@ type TagResponse struct {
 
 type Tag struct {
 	// タグID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 名前(30文字以内)
 	Name *string `json:"name"`
 	// ショートカット1 (255文字以内)
@@ -37,7 +37,7 @@ type Tag struct {
 
 type TagParams struct {
 	// 事業所ID
-	CompanyID int32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// メモタグ名 (30文字以内)
 	Name string `json:"name"`
 	// メモタグ検索用 (20文字以内)
@@ -47,13 +47,13 @@ type TagParams struct {
 }
 
 type GetTagsOpts struct {
-	Offset uint32 `url:"offset,omitempty"`
-	Limit  uint32 `url:"limit,omitempty"`
+	Offset int64 `url:"offset,omitempty"`
+	Limit  int64 `url:"limit,omitempty"`
 }
 
 func (c *Client) GetTags(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, opts GetTagsOpts,
+	companyID int64, opts GetTagsOpts,
 ) (*Tags, *oauth2.Token, error) {
 	var result Tags
 
@@ -84,7 +84,7 @@ func (c *Client) CreateTag(
 
 func (c *Client) GetTag(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, tagID uint32, opts GetTagsOpts,
+	companyID int64, tagID int64, opts GetTagsOpts,
 ) (*Tags, *oauth2.Token, error) {
 	var result Tags
 
@@ -103,7 +103,7 @@ func (c *Client) GetTag(
 
 func (c *Client) UpdateTag(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	tagID uint32, params TagParams,
+	tagID int64, params TagParams,
 ) (*Tag, *oauth2.Token, error) {
 	var result TagResponse
 	oauth2Token, err := c.call(ctx, path.Join(APIPathTags, fmt.Sprint(tagID)), http.MethodPut, oauth2Token, nil, params, &result)
@@ -115,7 +115,7 @@ func (c *Client) UpdateTag(
 
 func (c *Client) DestroyTag(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, tagID int32,
+	companyID int64, tagID int64,
 ) (*oauth2.Token, error) {
 	v, err := query.Values(nil)
 	if err != nil {

--- a/taxes.go
+++ b/taxes.go
@@ -30,7 +30,7 @@ type TaxCompanies struct {
 
 type TaxCompany struct {
 	// 税区分コード
-	Code int32 `json:"code"`
+	Code int64 `json:"code"`
 	// 税区分名
 	Name string `json:"name"`
 	// 税区分名（日本語表示用）
@@ -43,7 +43,7 @@ type TaxCompany struct {
 
 func (c *Client) GetTaxCompanies(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32,
+	companyID int64,
 ) (*TaxCompanies, *oauth2.Token, error) {
 	var result TaxCompanies
 

--- a/transactions.go
+++ b/transactions.go
@@ -27,27 +27,27 @@ type WalletTxnResponse struct {
 
 type WalletTxn struct {
 	// 明細ID
-	ID uint64 `json:"id"`
+	ID int64 `json:"id"`
 	// 事業所ID
-	CompanyID uint32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 取引日(yyyy-mm-dd)
 	Date string `json:"date"`
 	// 取引金額
 	Amount int64 `json:"amount"`
 	// 未決済金額
-	DueAmount int32 `json:"due_amount"`
+	DueAmount int64 `json:"due_amount"`
 	// 残高(銀行口座等)
-	Balance int32 `json:"balance"`
+	Balance int64 `json:"balance"`
 	// 入金／出金 (入金: income, 出金: expense)
 	EntrySide string `json:"entry_side"`
 	// 口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)
 	WalletableType string `json:"walletable_type"`
 	// 口座ID
-	WalletableID uint64 `json:"walletable_id"`
+	WalletableID int64 `json:"walletable_id"`
 	// 取引内容
 	Description string `json:"description"`
 	// 明細のステータス（消込待ち: 1, 消込済み: 2, 無視: 3, 消込中: 4, 対象外: 6）
-	Status uint `json:"status"`
+	Status int `json:"status"`
 	// 登録時に<a href=\"https://support.freee.co.jp/hc/ja/articles/202848350-明細の自動登録ルールを設定する\" target=\"_blank\">自動登録ルールの設定</a>が適用され、登録処理が実行された場合、 trueになります。〜を推測する、〜の消込をするの条件の場合は一致してもfalseになります。
 	RuleMatched bool `json:"rule_matched"`
 }
@@ -57,7 +57,7 @@ type GetWalletTxnOpts struct {
 	// 口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)
 	WalletableType string `url:"walletable_type,omitempty"`
 	// 口座ID
-	WalletableID uint64 `url:"walletable_id,omitempty"`
+	WalletableID int64 `url:"walletable_id,omitempty"`
 	// 取引日で絞込：開始日 (yyyy-mm-dd)
 	StartDate string `url:"start_date,omitempty"`
 	// 取引日で絞込：終了日 (yyyy-mm-dd)
@@ -65,9 +65,9 @@ type GetWalletTxnOpts struct {
 	// 入金／出金 (入金: income, 出金: expense)
 	EntrySide string `url:"entry_side,omitempty"`
 	// 取得レコードのオフセット (デフォルト: 0)
-	Offset uint32 `url:"offset,omitempty"`
+	Offset int64 `url:"offset,omitempty"`
 	// 取得レコードの件数 (デフォルト: 20, 最小: 1, 最大: 100)
-	Limit uint32 `url:"limit,omitempty"`
+	Limit int64 `url:"limit,omitempty"`
 }
 
 type WalletTxnCreateParams struct {
@@ -78,20 +78,20 @@ type WalletTxnCreateParams struct {
 	// 取引金額
 	Amount int64 `json:"amount"`
 	// 口座ID
-	WalletableID int32 `json:"walletable_id"`
+	WalletableID int64 `json:"walletable_id"`
 	// 口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)
 	WalletableType string `json:"walletable_type"`
 	// 取引日 (yyyy-mm-dd)
 	Date string `json:"date"`
 	// 事業所ID
-	CompanyID uint32 `json:"company_id"`
+	CompanyID int64 `json:"company_id"`
 	// 残高 (銀行口座等)
 	Balance *int64 `json:"balance,omitempty"`
 }
 
 func (c *Client) GetWalletTransactions(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, opts GetWalletTxnOpts) (*WalletTxnsResponse, *oauth2.Token, error) {
+	companyID int64, opts GetWalletTxnOpts) (*WalletTxnsResponse, *oauth2.Token, error) {
 	var result WalletTxnsResponse
 
 	if (opts.WalletableType != "" && opts.WalletableID == 0) || (opts.WalletableID != 0 && opts.WalletableType == "") {
@@ -114,7 +114,7 @@ func (c *Client) GetWalletTransactions(
 
 func (c *Client) GetWalletTransaction(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, txnID uint64, opts GetWalletTxnOpts,
+	companyID int64, txnID int64, opts GetWalletTxnOpts,
 ) (*WalletTxn, *oauth2.Token, error) {
 	var result WalletTxnResponse
 

--- a/users.go
+++ b/users.go
@@ -19,7 +19,7 @@ type Me struct {
 
 type User struct {
 	// ユーザーID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// メールアドレス
 	Email string `json:"email"`
 	// 表示ユーザー名
@@ -37,7 +37,7 @@ type User struct {
 
 type UserCompany struct {
 	// 事業所ID
-	ID int32 `json:"id"`
+	ID int64 `json:"id"`
 	// 表示名
 	DisplayName string `json:"display_name"`
 	// ユーザーの権限

--- a/util.go
+++ b/util.go
@@ -5,6 +5,6 @@ import (
 	"net/url"
 )
 
-func SetCompanyID(v *url.Values, companyID uint32) {
+func SetCompanyID(v *url.Values, companyID int64) {
 	v.Set("company_id", fmt.Sprintf("%d", companyID))
 }

--- a/walletabales.go
+++ b/walletabales.go
@@ -46,20 +46,20 @@ type WalletableCreateParams struct {
 	// 口座種別（bank_account : 銀行口座, credit_card : クレジットカード, wallet : その他の決済口座）
 	Type string `json:"type"`
 	// 事業所ID
-	CompanyId int32 `json:"company_id"`
+	CompanyId int64 `json:"company_id"`
 	// 連携サービスID（typeにbank_account、credit_cardを指定する場合は必須）
-	BankId *int32 `json:"bank_id,omitempty"`
+	BankId *int64 `json:"bank_id,omitempty"`
 	// 口座を資産口座とするか負債口座とするか（true: 資産口座 (デフォルト), false: 負債口座）<br> bank_idを指定しない場合にのみ使われます。<br> bank_idを指定する場合には資産口座か負債口座かはbank_idに指定したサービスに応じて決定され、is_assetに指定した値は無視されます。
 	IsAsset *bool `json:"is_asset,omitempty"`
 }
 
 type Walletable struct {
 	// 口座ID
-	ID uint64 `json:"id"`
+	ID int64 `json:"id"`
 	// 口座名 (255文字以内)
 	Name string `json:"name"`
 	// サービスID
-	BankID uint64 `json:"bank_id"`
+	BankID int64 `json:"bank_id"`
 	// 口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)
 	Type string `json:"type"`
 	// 同期残高
@@ -70,7 +70,7 @@ type Walletable struct {
 
 func (c *Client) GetWalletables(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, opts GetWalletablesOpts,
+	companyID int64, opts GetWalletablesOpts,
 ) (*WalletablesResponse, *oauth2.Token, error) {
 	var result WalletablesResponse
 
@@ -90,7 +90,7 @@ func (c *Client) GetWalletables(
 
 func (c *Client) GetWalletable(
 	ctx context.Context, oauth2Token *oauth2.Token,
-	companyID uint32, walletType string, walletableID uint64,
+	companyID int64, walletType string, walletableID int64,
 ) (*Walletable, *oauth2.Token, error) {
 	var result WalletableResponse
 


### PR DESCRIPTION
uintとの混在も扱いにくいのでint64に統一